### PR TITLE
View camera feed 22

### DIFF
--- a/robot/basestation/README.md
+++ b/robot/basestation/README.md
@@ -16,3 +16,5 @@ Run the app with `python app.py`
 You will see: `Running on http://127.0.0.1:5000`
 
 Visit this link in your browser to see the GUI.
+
+If the rover machine is running `StreamDispatcher.py`, then you will see a live video stream of the arm camera.

--- a/robot/basestation/app.py
+++ b/robot/basestation/app.py
@@ -6,12 +6,15 @@ import flask
 
 app = flask.Flask(__name__)
 
+# set the rover's IP
+# rover static ip TBD
+ROVER_IP = "127.31.43.134"
 
 # Once we launch this, this will route us to the "../" page or index page and
 # automatically render the Rover GUI
 @app.route("/")
 def index():
-    return flask.render_template("AsimovOperation.html")
+    return flask.render_template("AsimovOperation.html", roverIP=ROVER_IP)
 
 
 # Automatic controls

--- a/robot/basestation/app.py
+++ b/robot/basestation/app.py
@@ -7,7 +7,7 @@ import flask
 app = flask.Flask(__name__)
 
 # set the rover's IP
-# rover static ip TBD
+# rover static ip (tenatative): 192.168.1.20
 ROVER_IP = "127.31.43.134"
 
 # Once we launch this, this will route us to the "../" page or index page and

--- a/robot/basestation/templates/AsimovOperation.html
+++ b/robot/basestation/templates/AsimovOperation.html
@@ -65,7 +65,7 @@
                 </div>
                 <div class="col-md-6">
                     <h5 class="container-header">Arm Vision</h5>
-                    <img src="http://192.168.2.11:8090/?action=stream" class="img-fluid" alt="Responsive image"
+                    <img src="http://{{ roverIP }}:8090/?action=stream" class="img-fluid" alt="Responsive image"
                     />
                 </div>
             </div>

--- a/robot/basestation/templates/AsimovOperation.html
+++ b/robot/basestation/templates/AsimovOperation.html
@@ -33,7 +33,7 @@
         <a class="navbar-brand" href="#">
             <img src="https://spaceconcordia.github.io/img/sclogo_header.png">
         </a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" d ata-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault"
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault"
             aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -65,8 +65,8 @@
                 </div>
                 <div class="col-md-6">
                     <h5 class="container-header">Arm Vision</h5>
-                    <img src="http://{{ roverIP }}:8090/?action=stream" class="img-fluid" alt="Responsive image"
-                    />
+                    <!-- It would be preferable to use video tag, but mjpeg streams are not have no general support beyond img tags -->
+                    <img src="http://{{ roverIP }}:8090/?action=stream" class="img-fluid" alt="Arm Camera Stream Offline"/>
                 </div>
             </div>
 

--- a/robot/basestation/templates/AsimovOperation.html
+++ b/robot/basestation/templates/AsimovOperation.html
@@ -65,7 +65,7 @@
                 </div>
                 <div class="col-md-6">
                     <h5 class="container-header">Arm Vision</h5>
-                    <img src="http://www.grup-pumsa.cat/uploadwallimgs/b/41/413832_%D8%B5%D9%88%D8%B1-wallpaper.jpg" class="img-fluid" alt="Responsive image"
+                    <img src="http://192.168.2.11:8090/?action=stream" class="img-fluid" alt="Responsive image"
                     />
                 </div>
             </div>

--- a/robot/rover/README.md
+++ b/robot/rover/README.md
@@ -19,7 +19,8 @@ If you wish to refer the `include` statements to set your relative path to the l
 Currently this starts a stream via `start_stream.sh` which uses mjpgstreamer, more details are documented in the bash script itself.
 To start the stream, assuming you already have a usb web camera connected, run `./StreamDispatcher.py`. Use `Ctrl + C` to stop the stream.
 
-Assuming the stream is being dispatched, it can be accessed in any browser by visiting: `server_ip:8090/?action=stream`, where `server_ip` is replaced with the actual ip address.
+Assuming the stream is being dispatched, it can be accessed in any browser by visiting: `server_ip:8090/?action=stream`,
+where `server_ip` is replaced with the actual ip address  of the server doing the streaming.
 If you have started the StreamDispatcher, opening the Arm page will show the live of feed of the camera in the Arm Vision panel.
 The rover ip address in `app.py` will have to be set to the correct value.
 

--- a/robot/rover/README.md
+++ b/robot/rover/README.md
@@ -1,3 +1,6 @@
+# Rover
+The code that runs on the rover
+
 ## PidController.ino
 NOTE: the Adafruit library most probably won't end up being used since we decided against using adafruit motorshields in the end,
 although this sketch will be either heavily refactored or completely rewritten by operations and power squads for 3 stepper, 1 DC
@@ -11,6 +14,14 @@ Simply searching for 'adafruit' and 'encoder' and choosing the most appropriate 
 This method installs it in your arduino libraries folder.
 
 If you wish to refer the `include` statements to set your relative path to the libraries, you must surround the libary name with double quotes.
+
+## StreamDispatcher.py
+Currently this starts a stream via `start_stream.sh` which uses mjpgstreamer, more details are documented in the bash script itself.
+To start the stream, assuming you already have a usb web camera connected, run `./StreamDispatcher.py`. Use `Ctrl + C` to stop the stream.
+
+Assuming the stream is being dispatched, it can be accessed in any browser by visiting: `server_ip:8090/?action=stream`, where `server_ip` is replaced with the actual ip address.
+If you have started the StreamDispatcher, opening the Arm page will show the live of feed of the camera in the Arm Vision panel.
+The rover ip address in `app.py` will have to be set to the correct value.
 
 Example:
 `#include "libraries/Encoder.h"`

--- a/robot/rover/StreamDispatcher.py
+++ b/robot/rover/StreamDispatcher.py
@@ -1,15 +1,65 @@
+#!/usr/bin/env python
+
+import signal
+import subprocess
+import os
+import sys
+import time
+
 # for now methods that aren't fully implemented return False
 class StreamDispatcher:
+    stream_starter = "./start_stream.sh"
 
     def __init__(self):
-        self.current_fps = 25  # set default value
-        self.fps_cap = 30  # this should be a upper limit constant based of experimentation/known physical limits
-        self.status = False  # ON == true, OFF == false
-        self.brightness = 10  # decide on default value via experimentation
-        self.color = False  # turn off color by default
+        #self.current_fps = 25  # set default value
+        #self.fps_cap = 30  # this should be a upper limit constant based of experimentation/known physical limits
+        #self.status = False  # ON == true, OFF == false
+        #self.brightness = 10  # decide on default value via experimentation
+        #self.color = False  # turn off color by default
+        self.p1_pid = -1
+        self.p1 = 0
 
-    def start_udp_stream():
-        return False
+    def start_stream(self):
+        if os.path.isfile(self.stream_starter):
+            print("Starting camera stream...")
+            # non-blocking
+            self.p1 = subprocess.Popen(["sh", self.stream_starter], stdout=subprocess.PIPE)
+            self.p1_pid = self.p1.pid
+            print("process id: " + str(self.p1_pid))
+        else:
+            print("Failed to start camera stream")
 
-    def stop_udp_stream():
-        return False
+    def stop_stream(self):
+        if self.p1_pid > -1:
+            print("Terminating stream...")
+            self.p1.send_signal(signal.SIGINT)
+            print("Stream terminated")
+            self.steam_pid = -1
+            return True
+        else:
+            print("Failed to close video stream")
+            return False
+
+if __name__ == "__main__":
+
+    try:
+        dispatcher = StreamDispatcher()
+        dispatcher.start_stream()
+
+        while True:
+            continue
+
+    except KeyboardInterrupt:
+        dispatcher.stop_stream()
+        sys.exit(0)
+
+    # other attemps
+
+    # register Ctrl + c to call back function stop_stream
+    #signal.signal(signal.SIGINT, dispatcher.stop_stream)
+
+    # using signal over atexit to avoid empty while True
+    #atexit.register(dispatcher.stop_stream())
+
+    # wait for user to press ctrl + c
+    #signal.pause()

--- a/robot/rover/start_stream.sh
+++ b/robot/rover/start_stream.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# since this command usually requires to be run as sudo
+# this file was changed to be owned by root so it can be called
+# from other scripts without needing to run the initial script as sudo
+# this was achieved with `sudo chown root:root start_stream.sh`
+/usr/local/bin/mjpg_streamer  -i 'input_uvc.so -r 1280x720 -m 50000 -n -f 25 -d /dev/video0' -o 'output_http.so -p 8090 -w /usr/local/share/mjpg-streamer/www/'
+
+# to install dependencies:
+# $ git clone https://github.com/jacksonliam/mjpg-streamer.git
+# $ cd mjpg-streamer/mjpg-streamer-experimental
+# $ sudo apt-get install cmake libjpeg62-dev
+# $ make
+# $ sudo make install

--- a/robot/rover/start_stream.sh
+++ b/robot/rover/start_stream.sh
@@ -12,3 +12,6 @@
 # $ sudo apt-get install cmake libjpeg62-dev
 # $ make
 # $ sudo make install
+
+# NOTE: using mjpeg streams limits us to capturing them using more limited img tags
+# instead of the newer video tags


### PR DESCRIPTION
closes #22 

A very simple implementation allowing us to view the arm camera stream, given that the `StreamDispatcher.py` process is running on the rover.
The methods/libraries may have to be changed since mjpeg streams aren't generally supported past the`img` tag and using the newer HTML `video` tag would give us more to work with.
This implementation does _not_ implement starting the stream or stopping it via commands sent from the base station, nor updating FPs. The stream must be initiated manually from the rover itself.

Tested on a single server/client ubuntu 16.04 machine.

![proof-issue-22](https://user-images.githubusercontent.com/19865282/49323368-64785d80-f4e8-11e8-9675-3bf32a913583.png)
