### PR TITLE
Number prepender 67

### DIFF
--- a/PREPEND-README.md
+++ b/PREPEND-README.md
@@ -1,14 +1,42 @@
 # Bash hook to prepend branch name
 This explains how to use and setup a git hook that will prepend the issue number
-to a commit message.git hooks are used to automate git commands and functions. There are a number of different options, but this particular hook will add the issue number to your "git commit-m" message once it is pushed to the repository. Git hooks live in the git file of each repo, so initializing this hook in the robotics git will not change any other repos you might have.
+to a commit message. Git hooks are used to automate git commands and functions. There are a number of different options, but this particular hook will add the issue number to your "git commit-m" message once it is pushed to the repository. Git hooks live in a local git/hooks file of each repo, so initializing this hook in the robotics-prototype repo will not change any other repos you might have.
 
 ## Setting up a git hook
-In the space club repo directory find the git folder and open hooks contained there in. For robotics the address is:
+Windows:
+In your space concordia directory find the git folder and open hooks contained there in. It should look like this:
 
-/<your-loctation-of-repo>/robotics-protoype/git/hooks
+robotics-protoype/git/hooks
 
-once there open prepare-commit-msg.sample in your editor. Paste all the script from the prepender file over the sample code. then save the file and remove the .sample in the file name. that's it, the hook is up and running.
+once there open prepare-commit-msg.sample in your editor. Replace the code in the sample with the code found in commit-message-hook.sh. Save the file by keeping the name the same and removing the .sample suffix.
 
-## Using the commit hook prepender
+Linux:
 
-Now, whenever you using the git commit-m command the hook will prepend the issue number to your message. Note that you wont see this in bash or terminal, instead the issue will show up in the repo as [#<issue number>]. This will work as long as your branches are named using our branch naming standards of <word>-<word>-<issue number> .
+Open the .git/hooks folder. Should be in this directory:
+
+```
+robotics-protoype/.git/hooks
+```
+once there copy we need to make a copy of the prepare-commit-msg.sample :
+```
+$touch prepare-commit-msg.sample
+```
+copy contents of the sample to our new file:
+```
+$cp cp prepare-commit-msg.sample prepare-commit-msg
+```
+make the new file executable:
+```
+chmod +x prepare-commit-msg
+```
+
+Now open this file with your editor of choice and replace the code with that in commit-message-hook.sh. Save the file. The hook should now be set up.
+
+
+### Using the commit hook prepender
+
+Now, when ever you using the git commit-m command the hook will prepend the issue number to your message. This will show up in the repo as [#<issue number>], so there is no longer a need to add this to your commit message. This will work as long as your branches are named using our branch naming standards defind in our wiki, otherwise the commit will be aborted.
+
+in order to write a long commit message using git commit -m, write a concise title and then press enter twice before closing the quotation marks. Then, type as long a message as is appropriate and close the quation mark.
+
+Finish the commit and push as usual.

--- a/PREPEND-README.md
+++ b/PREPEND-README.md
@@ -1,0 +1,14 @@
+# Bash hook to prepend branch name
+This explains how to use and setup a git hook that will prepend the issue number
+to a commit message.git hooks are used to automate git commands and functions. There are a number of different options, but this particular hook will add the issue number to your "git commit-m" message once it is pushed to the repository. Git hooks live in the git file of each repo, so initializing this hook in the robotics git will not change any other repos you might have.
+
+## Setting up a git hook
+In the space club repo directory find the git folder and open hooks contained there in. For robotics the address is:
+
+/<your-loctation-of-repo>/robotics-protoype/git/hooks
+
+once there open prepare-commit-msg.sample in your editor. Paste all the script from the prepender file over the sample code. then save the file and remove the .sample in the file name. that's it, the hook is up and running.
+
+## Using the commit hook prepender
+
+Now, whenever you using the git commit-m command the hook will prepend the issue number to your message. Note that you wont see this in bash or terminal, instead the issue will show up in the repo as [#<issue number>]. This will work as long as your branches are named using our branch naming standards of <word>-<word>-<issue number> .

--- a/PREPEND-README.md
+++ b/PREPEND-README.md
@@ -1,42 +1,27 @@
 # Bash hook to prepend branch name
 This explains how to use and setup a git hook that will prepend the issue number
-to a commit message. Git hooks are used to automate git commands and functions. There are a number of different options, but this particular hook will add the issue number to your "git commit-m" message once it is pushed to the repository. Git hooks live in a local git/hooks file of each repo, so initializing this hook in the robotics-prototype repo will not change any other repos you might have.
+to a commit message. Git hooks are used to automate git commands and functions. There are a number of different options, but this particular hook will add the issue number to your ```git commit-m``` message once it is pushed to the repository. Git hooks live in a local git/hooks file of each repo, so initializing this hook in the robotics-prototype repo will not change any other repos you might have.
 
 ## Setting up a git hook
 Windows:
 In your space concordia directory find the git folder and open hooks contained there in. It should look like this:
-
+```
 robotics-protoype/git/hooks
+```
 
-once there open prepare-commit-msg.sample in your editor. Replace the code in the sample with the code found in commit-message-hook.sh. Save the file by keeping the name the same and removing the .sample suffix.
+Once there open ```prepare-commit-msg.sample``` in your editor. Replace the code in the sample with the code found in ```commit-message-hook.sh.``` Save the file by keeping the name the same and removing the .sample suffix.
 
 Linux:
 
-Open the .git/hooks folder. Should be in this directory:
-
+From the root of the repository:
 ```
-robotics-protoype/.git/hooks
+cp commit-message-hook.sh .git/hooks/prepare-commit-msg
 ```
-once there copy we need to make a copy of the prepare-commit-msg.sample :
-```
-$touch prepare-commit-msg.sample
-```
-copy contents of the sample to our new file:
-```
-$cp cp prepare-commit-msg.sample prepare-commit-msg
-```
-make the new file executable:
-```
-chmod +x prepare-commit-msg
-```
-
-Now open this file with your editor of choice and replace the code with that in commit-message-hook.sh. Save the file. The hook should now be set up.
-
 
 ### Using the commit hook prepender
 
-Now, when ever you using the git commit-m command the hook will prepend the issue number to your message. This will show up in the repo as [#<issue number>], so there is no longer a need to add this to your commit message. This will work as long as your branches are named using our branch naming standards defind in our wiki, otherwise the commit will be aborted.
+Now, when ever you using ```git commit-m``` the hook will prepend the issue number to your message. This will show up in the repo as [#<issue number>], so there is no longer a need to add this to your commit message. This will work as long as your branches are named using our branch naming standards defind in our wiki, otherwise the commit will be aborted.
 
-in order to write a long commit message using git commit -m, write a concise title and then press enter twice before closing the quotation marks. Then, type as long a message as is appropriate and close the quation mark.
+In order to write a long commit message using ```git commit -m```, write a concise title and then press enter twice. Then, type as long a message as is appropriate and close the quation mark. This ensures it will be formatted nicely on github.
 
-Finish the commit and push as usual.
+Finish the commit and ```git push``` as usual.

--- a/commit-message-hook.sh
+++ b/commit-message-hook.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Include any branches for which you wish to disable this script
+if [ -z "$BRANCHES_TO_SKIP" ]; then
+  BRANCHES_TO_SKIP=(master develop staging test)
+fi
+
+# Get the current branch name and check if it is excluded
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
+
+# Trims down the branch name to only include the issue number.
+TRIMMED=$(echo $BRANCH_NAME | sed -e 's/[^0-9][^0-9]*\([0-9][0-9]*\).*/\1/g' )
+
+# If it isn't excluded, preprend the trimmed branch identifier to the given message
+if [ -n "$BRANCH_NAME" ] &&  ! [[ $BRANCH_EXCLUDED -eq 1 ]]; then
+  sed -i.bak -e "1s/^/[#$TRIMMED] /" $1
+fi

--- a/commit-message-hook.sh
+++ b/commit-message-hook.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
+
 # Include any branches for which you wish to disable this script
-if [ -z "$BRANCHES_TO_SKIP" ]; then
   BRANCHES_TO_SKIP=(master develop staging test)
-fi
-# Get the current branch name and check if it is excluded
+
+# Get the current branch name
 BRANCH_NAME=$(git symbolic-ref --short HEAD)
-BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
 
 # Trims down the branch name to only include the issue number.
 TRIMMED=$(echo $BRANCH_NAME | sed -e 's/[^0-9][^0-9]*\([0-9][0-9]*\).*/\1/g' )
 
+#Checks to see if branch is excluded, if so exit script and allow regular commit
+#If branch is not excluded, then proceed with script
+if [[ $BRANCH_NAME == $BRANCHES_TO_SKIP  ]];then
+	exit 0
+fi
 #checks to make sure trimmed is a number, if not it exits and tells user to check wiki
 if [[ $TRIMMED =~ [\$0-9] ]];then
 # If it isn't excluded, preprend the trimmed branch identifier to the given message
-  if [ -n "$BRANCH_NAME" ] &&  ! [[ $BRANCH_EXCLUDED -eq 1 ]]; then
+  if [ -n "$BRANCH_NAME" ]  && [[ ! $BRANCH_EXCLUDED -eq 1 ]]; then
     sed -i.bak -e "1s/^/[#$TRIMMED] /" $1
-  fi
-else
-  echo "branch name is not named properly, please see wiki for formating"
-  exit 1
+fi
+ else
+    echo "Branch name is not named properly, please see wiki for formating: https://github.com/space-concordia-robotics/robotics-prototype/wiki/Work-Flow"
+    exit 1
 fi

--- a/commit-message-hook.sh
+++ b/commit-message-hook.sh
@@ -3,7 +3,6 @@
 if [ -z "$BRANCHES_TO_SKIP" ]; then
   BRANCHES_TO_SKIP=(master develop staging test)
 fi
-
 # Get the current branch name and check if it is excluded
 BRANCH_NAME=$(git symbolic-ref --short HEAD)
 BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
@@ -11,7 +10,13 @@ BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAM
 # Trims down the branch name to only include the issue number.
 TRIMMED=$(echo $BRANCH_NAME | sed -e 's/[^0-9][^0-9]*\([0-9][0-9]*\).*/\1/g' )
 
+#checks to make sure trimmed is a number, if not it exits and tells user to check wiki
+if [[ $TRIMMED =~ [\$0-9] ]];then
 # If it isn't excluded, preprend the trimmed branch identifier to the given message
-if [ -n "$BRANCH_NAME" ] &&  ! [[ $BRANCH_EXCLUDED -eq 1 ]]; then
-  sed -i.bak -e "1s/^/[#$TRIMMED] /" $1
+  if [ -n "$BRANCH_NAME" ] &&  ! [[ $BRANCH_EXCLUDED -eq 1 ]]; then
+    sed -i.bak -e "1s/^/[#$TRIMMED] /" $1
+  fi
+else
+  echo "branch name is not named properly, please see wiki for formating"
+  exit 1
 fi

--- a/commit-message-hook.sh
+++ b/commit-message-hook.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-
+#If there is already a commit message this hook is disabled
+if [[ "$2" = "commit" ]]; then
+    #statements
+    exit 0
+fi
 # Include any branches for which you wish to disable this script
   BRANCHES_TO_SKIP=(master develop staging test)
 

--- a/tests/functional/commit-prepender/prependertester.sh
+++ b/tests/functional/commit-prepender/prependertester.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+BRANCH_NAME=$1
+
+# Trims down the branch name to only include the issue number.
+TRIMMED=$(echo $BRANCH_NAME | sed -e 's/[^0-9][^0-9]*\([0-9][0-9]*\).*/\1/g' )
+
+echo "TRIMMED: $TRIMMED"


### PR DESCRIPTION
Closes #67

Bash helper script to capture issue number from branch name and prepend it to commit message such as “[#<issue number>] ” using git hooks. 
- [x] add the ability to validate the branches. Commit will be exited if branch is named incorrectly
- [x] include a README that describes how to set up got hook on windows and linux