### PR TITLE
Multiple cameras 101

### DIFF
--- a/robot/rospackages/src/CMakeLists.txt
+++ b/robot/rospackages/src/CMakeLists.txt
@@ -1,1 +1,1 @@
-C:/opt/ros/kinetic/share/catkin/cmake/toplevel.cmake
+/opt/ros/kinetic/share/catkin/cmake/toplevel.cmake

--- a/robot/rospackages/src/task_handler/scripts/Listener.py
+++ b/robot/rospackages/src/task_handler/scripts/Listener.py
@@ -8,7 +8,7 @@ import time
 from robot.basestation.app import run_shell, get_pid
 
 class Listener:
-    def __init__(self, script, type, force_kill=False, children=0):
+    def __init__(self, script, type, args='', force_kill=False, children=0):
         # initialize pid to -1 to imply process hasn't yet started
         self.p1_pid = -1
         # the actual process object itself
@@ -21,6 +21,8 @@ class Listener:
         self.force_kill = force_kill
         # amount of children processes spawned
         self.children = children
+        # arguments for scripts
+        self.args = args
 
     def start(self):
         if self.is_running():
@@ -30,7 +32,11 @@ class Listener:
         if os.path.isfile(self.script):
             print("Starting listener service...")
             # non-blocking
-            self.p1 = subprocess.Popen([self.type, self.script], stdout=subprocess.PIPE)
+            if self.args:
+                self.p1 = subprocess.Popen([self.type, self.script, self.args], stdout=subprocess.PIPE)
+            else:
+                self.p1 = subprocess.Popen([self.type, self.script], stdout=subprocess.PIPE)
+
             self.p1_pid = self.p1.pid
 
             # allow some time to pass
@@ -99,7 +105,9 @@ class Listener:
 if __name__ == "__main__":
 
     try:
-        dispatcher = Listener("/home/odroid/Programming/robotics-prototype/robot/rover/ArmCommandListener.py", "python3")
+        current_dir = os.path.dirname(os.path.realpath(__file__)) + "/"
+        dispatcher = Listener(current_dir + "start_stream.sh", "bash")
+        #dispatcher = Listener(current_dir + "start_stream.sh", "bash", "/dev/video0")
         dispatcher.start()
 
         print("Is running: " + str(dispatcher.is_running()))

--- a/robot/rospackages/src/task_handler/scripts/Listener.py
+++ b/robot/rospackages/src/task_handler/scripts/Listener.py
@@ -101,6 +101,10 @@ class Listener:
 
         return True
 
+
+    def get_args(self):
+        return self.args
+
 # quick test for verification
 if __name__ == "__main__":
 

--- a/robot/rospackages/src/task_handler/scripts/Listener.py
+++ b/robot/rospackages/src/task_handler/scripts/Listener.py
@@ -23,6 +23,7 @@ class Listener:
         self.children = children
         # arguments for scripts
         self.args = args
+        self.name = "none"
 
     def start(self):
         if self.is_running():
@@ -104,6 +105,12 @@ class Listener:
 
     def get_args(self):
         return self.args
+
+    def set_name(self, name):
+        self.name = name
+
+    def get_name(self):
+        return self.name
 
 # quick test for verification
 if __name__ == "__main__":

--- a/robot/rospackages/src/task_handler/scripts/Listener.py
+++ b/robot/rospackages/src/task_handler/scripts/Listener.py
@@ -41,9 +41,9 @@ class Listener:
             self.p1_pid = self.p1.pid
 
             # allow some time to pass
-            # specifically waiting for 4 seconds since command listener scripts
+            # specifically waiting for 3 seconds since command listener scripts
             # take an extra 2-3 seconds time to identify if the correct MCU is connected
-            time.sleep(4)
+            time.sleep(3)
 
             poll = self.p1.poll()
 

--- a/robot/rospackages/src/task_handler/scripts/ScienceCommandListener.py
+++ b/robot/rospackages/src/task_handler/scripts/ScienceCommandListener.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+import time
+
+while True:
+    print("I'm sciencing as fast as I can!")
+    time.sleep(1)

--- a/robot/rospackages/src/task_handler/scripts/start_stream.sh
+++ b/robot/rospackages/src/task_handler/scripts/start_stream.sh
@@ -9,9 +9,18 @@ DEVICES="$(v4l2-ctl --list-devices)"
 
 echo "$DEVICES" > tmp
 
-port=`tail -1 tmp`
-port="$(echo -e "${port}" | sed -e 's/^[[:space:]]*//')"
-echo "port: $port"
+
+if [ $# -eq 0 ]
+  then
+    echo "No arguments supplied"
+    port=`tail -1 tmp`
+    port="$(echo -e "${port}" | sed -e 's/^[[:space:]]*//')"
+    echo "port: $port"
+  else
+    echo "Port argument supplied: $1"
+    port=$1
+fi
+
 
 /usr/local/bin/mjpg_streamer  -i "input_uvc.so -r 640x480 -m 50000 -n -f 1 -d $port" -o "output_http.so -p 8090 -w /usr/local/share/mjpg-streamer/www/"
 

--- a/robot/rospackages/src/task_handler/scripts/task_handler_client.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_client.py
@@ -16,7 +16,7 @@ def task_handler_client(r_task, r_status, r_args=""):
     except rospy.ServiceException as e:
         print("Service call failed: {:s}".format(str(e)))
 
-def is_valid_request(r_task, r_status):
+def is_valid_request(r_task, r_status, r_args):
     """
     Validate client request parameters
     r_task: requested task
@@ -27,8 +27,11 @@ def is_valid_request(r_task, r_status):
 
     # all known tasks to be handled by the handler
     known_tasks = ["rover_listener", "arm_listener", "camera_stream"]
+    camera_args = ["/dev/ttyFrontCam", "/dev/ttyRearCam", "/dev/ttyArmScience"]
 
     if r_task in known_tasks and r_status in [0, 1]:
+        if r_task == "camera_stream" and not r_args in camera_args:
+            return False
         return True
 
     return False
@@ -58,7 +61,7 @@ if __name__ == "__main__":
     else:
         args = ""
 
-    if not is_valid_request(task, status):
+    if not is_valid_request(task, status, args):
         print("Invalid format")
         print(usage())
         sys.exit(0)

--- a/robot/rospackages/src/task_handler/scripts/task_handler_client.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_client.py
@@ -5,13 +5,13 @@ import datetime
 import rospy
 from task_handler.srv import *
 
-def task_handler_client(r_task, r_status):
+def task_handler_client(r_task, r_status, r_args=""):
     # convenience function that blocks until 'task_handler' is available
     #rospy.wait_for_service('task_handler')
 
     try:
         task_handle = rospy.ServiceProxy('task_handler', HandleTask)
-        resp1 = task_handle(task, int(status))
+        resp1 = task_handle(task, int(status), r_args)
         return resp1.response
     except rospy.ServiceException as e:
         print("Service call failed: {:s}".format(str(e)))
@@ -39,11 +39,12 @@ def usage():
     """
     help_msg = """USAGE:\nrosrun task_handler task_handler_client.py [task] [status]
                   \nValid task options: ['rover_listener', 'arm_listener', 'camera_stream']
-                  \nValid status options: [0, 1]"""
+                  \nValid status options: [0, 1]
+                  \nValid camera stream args: ['/dev/ttyFrontCam', '/dev/ttyRearCam/', '/dev/ttyArmScienceCam/']"""
     return help_msg
 
 if __name__ == "__main__":
-    if len(sys.argv) < 3 or len(sys.argv) > 3:
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
         print(usage())
         sys.exit(1)
 
@@ -51,6 +52,9 @@ if __name__ == "__main__":
 
     task = sys.argv[1]
     status = int(sys.argv[2])
+
+    if len(sys.argv) == 4:
+        args = sys.argv[3]
 
     if not is_valid_request(task, status):
         print("Invalid format")

--- a/robot/rospackages/src/task_handler/scripts/task_handler_client.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_client.py
@@ -27,7 +27,7 @@ def is_valid_request(r_task, r_status, r_args):
 
     # all known tasks to be handled by the handler
     known_tasks = ["arm_listener", "rover_listener", "science_listener", "camera_stream"]
-    camera_args = ["/dev/ttyFrontCam", "/dev/ttyRearCam", "/dev/ttyArmScience"]
+    camera_args = ["/dev/ttyFrontCam", "/dev/ttyRearCam", "/dev/ttyArmScienceCam"]
 
     if r_task in known_tasks and r_status in [0, 1, 2]:
         if r_task == "camera_stream" and not r_args in camera_args:
@@ -43,7 +43,7 @@ def usage():
     help_msg = """USAGE:\nrosrun task_handler task_handler_client.py [task] [status] optional:[args]
                   \nValid task options: ['arm_listener', 'arm_listener', 'science_listener', 'camera_stream']
                   \nValid status options: [0, 1, 2]
-                  \nValid camera stream args: ['/dev/ttyFrontCam', '/dev/ttyRearCam/', '/dev/ttyArmScienceCam/']"""
+                  \nValid camera stream args: ['/dev/ttyFrontCam', '/dev/ttyRearCam', '/dev/ttyArmScienceCam']"""
     return help_msg
 
 if __name__ == "__main__":

--- a/robot/rospackages/src/task_handler/scripts/task_handler_client.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_client.py
@@ -29,7 +29,7 @@ def is_valid_request(r_task, r_status, r_args):
     known_tasks = ["rover_listener", "arm_listener", "camera_stream"]
     camera_args = ["/dev/ttyFrontCam", "/dev/ttyRearCam", "/dev/ttyArmScience"]
 
-    if r_task in known_tasks and r_status in [0, 1]:
+    if r_task in known_tasks and r_status in [0, 1, 2]:
         if r_task == "camera_stream" and not r_args in camera_args:
             return False
         return True

--- a/robot/rospackages/src/task_handler/scripts/task_handler_client.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_client.py
@@ -26,7 +26,7 @@ def is_valid_request(r_task, r_status, r_args):
     r_status = int(r_status)
 
     # all known tasks to be handled by the handler
-    known_tasks = ["rover_listener", "arm_listener", "camera_stream"]
+    known_tasks = ["arm_listener", "rover_listener", "science_listener", "camera_stream"]
     camera_args = ["/dev/ttyFrontCam", "/dev/ttyRearCam", "/dev/ttyArmScience"]
 
     if r_task in known_tasks and r_status in [0, 1, 2]:
@@ -40,13 +40,14 @@ def usage():
     """
     Return string showcasing proper usage of this client script
     """
-    help_msg = """USAGE:\nrosrun task_handler task_handler_client.py [task] [status]
-                  \nValid task options: ['rover_listener', 'arm_listener', 'camera_stream']
-                  \nValid status options: [0, 1]
+    help_msg = """USAGE:\nrosrun task_handler task_handler_client.py [task] [status] optional:[args]
+                  \nValid task options: ['arm_listener', 'arm_listener', 'science_listener', 'camera_stream']
+                  \nValid status options: [0, 1, 2]
                   \nValid camera stream args: ['/dev/ttyFrontCam', '/dev/ttyRearCam/', '/dev/ttyArmScienceCam/']"""
     return help_msg
 
 if __name__ == "__main__":
+    # check for invalid ranges for args
     if len(sys.argv) < 3 or len(sys.argv) > 4:
         print(usage())
         sys.exit(1)

--- a/robot/rospackages/src/task_handler/scripts/task_handler_client.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_client.py
@@ -55,6 +55,8 @@ if __name__ == "__main__":
 
     if len(sys.argv) == 4:
         args = sys.argv[3]
+    else:
+        args = ""
 
     if not is_valid_request(task, status):
         print("Invalid format")
@@ -67,7 +69,7 @@ if __name__ == "__main__":
     print(sent_ts)
     print("---")
 
-    print("Response: " + str(task_handler_client(task, status)))
+    print("Response: " + str(task_handler_client(task, status, args)))
     received = datetime.datetime.now()
     received_st = sent.strftime('%Y-%m-%dT%H:%M:%S') + ('-%02d' % (received.microsecond / 10000))
     print(received_st)

--- a/robot/rospackages/src/task_handler/scripts/task_handler_server.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_server.py
@@ -24,7 +24,7 @@ def handle_task(task, status, args):
 
     global running_tasks
 
-    if status in [0, 1] and task in known_tasks:
+    if status in [0, 1, 2] and task in known_tasks:
         # set index for corresponding listener object in array
         i = 0
 
@@ -32,6 +32,11 @@ def handle_task(task, status, args):
             if t.partition("_")[0] in task:
                 chosen_task = t
                 print('task chosen:', chosen_task)
+
+                if status == 2:
+                    response = chosen_task
+                    is_running_str = " is running" if running_tasks[i].is_running() else " is not running"
+                    return response + is_running_str + "\n"
 
                 # reinitialize Listener object with proper arguments if necessary, or quit early if nonesense request
                 if chosen_task == "camera_stream":

--- a/robot/rospackages/src/task_handler/scripts/task_handler_server.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_server.py
@@ -7,7 +7,6 @@ from task_handler.srv import *
 import glob
 
 current_dir = os.path.dirname(os.path.realpath(__file__)) + "/"
-print(current_dir)
 scripts = [current_dir + "RoverCommandListener.py", current_dir + "ArmCommandListener.py", current_dir + "ScienceCommandListener.py", current_dir + "start_stream.sh"]
 running_tasks = [Listener(scripts[0], "python3"), Listener(scripts[1], "python3"), Listener(scripts[2], "python3"), Listener(scripts[3], "bash", "", 1, True)]
 known_tasks = ["rover_listener", "arm_listener", "science_listener", "camera_stream"]
@@ -45,7 +44,6 @@ def handle_task(task, status, args):
                     return response + is_running_str + "\n"
 
                 if chosen_task in known_listeners:
-#                    other_listeners = list(known_listeners)
                     other_listeners = [x for x in known_listeners if x != chosen_task]
 
                     for listener in running_tasks:

--- a/robot/rospackages/src/task_handler/scripts/task_handler_server.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_server.py
@@ -33,10 +33,14 @@ def handle_task(task, status, args):
                 chosen_task = t
                 print('task chosen:', chosen_task)
 
-                if chosen_task == "camera_stream" and not running_tasks[i].is_running():
-                    print("CAMERA_STREAM")
+                # reinitialize Listener object with proper arguments if necessary, or quit early if nonesense request
+                if chosen_task == "camera_stream":
+                    if running_tasks[i].is_running() and args != running_tasks[i].get_args():
+                        response = "Camera stream already running on port " + running_tasks[i].get_args()
+                        response += "\nTurn this stream of before starting or stopping a new one\n"
+                        return response
                     # set appropriate usb port in args
-                    if args:
+                    elif args and not running_tasks[i].is_running():
                         ports = glob.glob('/dev/tty[A-Za-z]*')
                         if args in ports:
                             running_tasks[i] = Listener(scripts[i], "bash", args, 1, True)

--- a/robot/rospackages/src/task_handler/scripts/task_handler_server.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_server.py
@@ -32,7 +32,7 @@ def handle_task(task, status, args):
                 chosen_task = t
                 print('task chosen:', chosen_task)
 
-                if chosen_task == "camera_stream":
+                if chosen_task == "camera_stream" and not running_tasks[i].is_running():
                     print("CAMERA_STREAM")
                     # set appropriate usb port in args
                     if args:

--- a/robot/rospackages/src/task_handler/scripts/task_handler_server.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_server.py
@@ -8,15 +8,16 @@ from task_handler.srv import *
 current_dir = os.path.dirname(os.path.realpath(__file__)) + "/"
 print(current_dir)
 scripts = [current_dir + "RoverCommandListener.py", current_dir + "ArmCommandListener.py", current_dir + "start_stream.sh"]
-running_tasks = [Listener(scripts[0], "python3"), Listener(scripts[1], "python3"), Listener(scripts[2], "bash", 1, True)]
+running_tasks = [Listener(scripts[0], "python3"), Listener(scripts[1], "python3"), Listener(scripts[2], "bash", "", 1, True)]
 known_tasks = ["rover_listener", "arm_listener", "camera_stream"]
 
+# return the response string after calling the task handling function
 def handle_task_request(req):
-    response = "\n" + handle_task(req.task, req.status)
+    response = "\n" + handle_task(req.task, req.status, req.args)
 
     return response
 
-def handle_task(task, status):
+def handle_task(task, status, args):
 
     response = "Nothing happened"
 
@@ -30,6 +31,12 @@ def handle_task(task, status):
             if t.partition("_")[0] in task:
                 chosen_task = t
                 print('task chosen:', chosen_task)
+
+                if chosen_task == "camera_stream":
+                    print("CAMERA_STREAM")
+                    # set appropriate usb port in args
+                    if args:
+                        running_tasks[i] = Listener(scripts[i], "bash", args, 1, True)
                 break
             i += 1
 

--- a/robot/rospackages/src/task_handler/scripts/task_handler_server.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_server.py
@@ -4,6 +4,7 @@ import rospy
 import os
 from Listener import Listener
 from task_handler.srv import *
+import glob
 
 current_dir = os.path.dirname(os.path.realpath(__file__)) + "/"
 print(current_dir)
@@ -36,7 +37,12 @@ def handle_task(task, status, args):
                     print("CAMERA_STREAM")
                     # set appropriate usb port in args
                     if args:
-                        running_tasks[i] = Listener(scripts[i], "bash", args, 1, True)
+                        ports = glob.glob('/dev/tty[A-Za-z]*')
+                        if args in ports:
+                            running_tasks[i] = Listener(scripts[i], "bash", args, 1, True)
+                        else:
+                            response = "Requested port not available, is the camera properly plugged into the USB port?"
+                            return response + "\n"
                 break
             i += 1
 

--- a/robot/rospackages/src/task_handler/scripts/task_handler_server.py
+++ b/robot/rospackages/src/task_handler/scripts/task_handler_server.py
@@ -8,9 +8,15 @@ import glob
 
 current_dir = os.path.dirname(os.path.realpath(__file__)) + "/"
 print(current_dir)
-scripts = [current_dir + "RoverCommandListener.py", current_dir + "ArmCommandListener.py", current_dir + "start_stream.sh"]
-running_tasks = [Listener(scripts[0], "python3"), Listener(scripts[1], "python3"), Listener(scripts[2], "bash", "", 1, True)]
-known_tasks = ["rover_listener", "arm_listener", "camera_stream"]
+scripts = [current_dir + "RoverCommandListener.py", current_dir + "ArmCommandListener.py", current_dir + "ScienceCommandListener.py", current_dir + "start_stream.sh"]
+running_tasks = [Listener(scripts[0], "python3"), Listener(scripts[1], "python3"), Listener(scripts[2], "python3"), Listener(scripts[3], "bash", "", 1, True)]
+known_tasks = ["rover_listener", "arm_listener", "science_listener", "camera_stream"]
+known_listeners = known_tasks[:-1]
+
+i = 0
+for task in running_tasks:
+    task.set_name(known_tasks[i])
+    i += 1
 
 # return the response string after calling the task handling function
 def handle_task_request(req):
@@ -37,6 +43,15 @@ def handle_task(task, status, args):
                     response = chosen_task
                     is_running_str = " is running" if running_tasks[i].is_running() else " is not running"
                     return response + is_running_str + "\n"
+
+                if chosen_task in known_listeners:
+#                    other_listeners = list(known_listeners)
+                    other_listeners = [x for x in known_listeners if x != chosen_task]
+
+                    for listener in running_tasks:
+                        if listener.get_name() in other_listeners and listener.is_running():
+                            response = listener.get_name() + " is running, kill it before running " + chosen_task
+                            return response + "\n"
 
                 # reinitialize Listener object with proper arguments if necessary, or quit early if nonesense request
                 if chosen_task == "camera_stream":

--- a/robot/rospackages/src/task_handler/srv/HandleTask.srv
+++ b/robot/rospackages/src/task_handler/srv/HandleTask.srv
@@ -1,4 +1,5 @@
 string task
 int64 status
+string args
 ---
 string response

--- a/robot/rover/gpio/README.md
+++ b/robot/rover/gpio/README.md
@@ -1,6 +1,6 @@
 # gpio
 
-Files required for setting up gpio pins on the odroid XU4.
+Files required for setting up gpio pins on the odroid XU4, as well as some udev rules.
 
 ## rc.local
 
@@ -23,3 +23,12 @@ to utilize the gpio bash functionality without needing to be root. Those necessa
 If this file does not exist in the `/etc/udev/rules.d` folder, create it. Otherwise append the contents to your already existing version.
 Then you must make sure to add the default user `odroid` to the group `gpio` with: `usermod -a -G gpio odroid`. You may need to create the group first with:
 `sudo groupadd gpio`. You will have to reboot for the effects to take place.
+
+## my-webcams.rules
+
+### Purpose
+On bootup this file will ensure that specific physical usb ports get mapped to specific names so that we can always refer to them from code accurately, assuming the devices are plugged into the appropriate usb ports.
+This was mainly done to handle multiple cameras (of the same make/model, thus virtually indistinguishable) so that they can be programmatically addressed.
+
+### Setup
+This file should be inside the `/etc/udev/rules.d/` folder.

--- a/robot/rover/gpio/my-webcams.rules
+++ b/robot/rover/gpio/my-webcams.rules
@@ -1,0 +1,4 @@
+SUBSYSTEM=="video4linux", ENV{ID_PATH}=="platform-12110000.usb:-usb-0:1:1.0", SYMLINK+="ttyArmScienceCam"
+SUBSYSTEM=="video4linux", ENV{ID_PATH}=="platform-xhci-hcd.2.auto-usb-0:1.2:1.0", SYMLINK+="ttyFrontCam"
+SUBSYSTEM=="video4linux", ENV{ID_PATH}=="platform-xhci-hcd.2.auto-usb-0:1.1:1.0", SYMLINK+="ttyRearCam"
+


### PR DESCRIPTION
## Summary
All backend changes here, no frontend updates.
As long as we keep the usb ports for specific cameras, the changes in this PR will allow us to activate multiple different camera streams one at a time. No two streams can be on at the same time.
Additional upgrades were made to the task_handler ros service, as well as the Listener class to achieve this.
Now we can pass args as a third argument in the client calls, as well as query the running status of any task. Extra protection against running multiple "listener" type tasks was added for safety reasons, since we suspect that having multiple listeners opening the same serial port would mess things up for `pyserial`.

Still need to add UI changes but waiting to merge @vashmata 's branch regarding issue #99 first