### PR TITLE
Allow venv to work with rosbridge_server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ tornado==6.0.2
 bson==0.5.8
 pymongo==3.8.0
 image==1.5.27
+Twisted==19.7.0

--- a/robot/basestation/config/.bash_aliases
+++ b/robot/basestation/config/.bash_aliases
@@ -26,4 +26,4 @@ alias nani=". $NANORC"
 alias roverenv=". $ROBOTICS_WS/venv/bin/activate"
 alias startgui="roverenv && cd $BASE && python app.py"
 # we have to deactivate venv for this launch file to not break, bug to be resolved eventually
-alias rosgui="roverenv && deactivate && roslaunch rosbridge_server rosbridge_websocket.launch"
+alias rosgui="roslaunch rosbridge_server rosbridge_websocket.launch"


### PR DESCRIPTION
Closes #152 

I found the fix to run venv (python3+) with rosbridge_server, I simply had to install the missing python libraries, which in this case, only needed one. However I get this warning in the log `Failed to load Python extension for LZ4 support. LZ4 compression will not be available.`. I have not seen any effects of this warning, but I think we should definitely make sure everything is still functional considering that there's comp in like two weeks.

I'm assuming that it's the same issue for @vashmata @alihessami in your branch, some python packages probably just need to be put in `requirements.txt`

**Make sure you run `pip install -r requirements.txt`**
