### PR TITLE
[#183] Bypass submodules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ install:
 script:
   # - cd tests/unit/ # unnecessary
   - pytest
+
+# bypass submodules because gitlab requires authentication for pull
+git:
+  submodules: false


### PR DESCRIPTION
Closes #183 

For some reasons unknown, the check marks underneath our commits have disappeared. But when I sign into the travis site I can see the build history and now travis seems appeased.
We currently do not require those dependencies to run any unit tests or any other kind of tests. In the future, if we will need to, we could probably create a neutral user account just for this purpose so that travis can use it's credentials.