### PR TITLE
Readd venv deactivation protection

### DIFF
--- a/robot/basestation/config/.bash_aliases
+++ b/robot/basestation/config/.bash_aliases
@@ -27,4 +27,4 @@ alias updateEnv="sh $BASE/env.sh > $BASE/static/js/env.js"
 alias roverenv=". $ROBOTICS_WS/venv/bin/activate"
 alias startgui="updateEnv && roverenv && cd $BASE && python app.py"
 # we have to deactivate venv for this launch file to not break, bug to be resolved eventually
-alias rosgui="roslaunch rosbridge_server rosbridge_websocket.launch"
+alias rosgui="roverenv && deactivate && roslaunch rosbridge_server rosbridge_websocket.launch"


### PR DESCRIPTION
This is because there is an issue with `venv` activated while launching rosbridge