### PR TITLE
Roslibjs logging 211

### DIFF
--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -205,7 +205,7 @@ function initRosWeb () {
 
 /* functions used in main code */
 
-function getTimestamp () {
+function rosTimestamp () {
   // next few lines taken and adjusted from roslibjs action server example
   let currentTime = new Date()
   let secs = currentTime.getTime()/1000 // seconds before truncating the decimal
@@ -238,49 +238,27 @@ function publishRosLog (logLevel, timestamp, message) {
 }
 
 function rosLog (logLevel, message) {
-  let prefix, isError
-  switch (logLevel) {
-    case ROSDEBUG:
-      // unlike rospy, currently the debug messages we generate will get published
-      prefix = '[DEBUG]'
-      isError = false
-      break
-    case ROSINFO:
-      prefix = '[INFO]'
-      isError = false
-      break
-    case ROSWARN:
-      prefix = '[WARN]'
-      isError = true
-      break
-    case ROSERROR:
-      prefix = '[ERROR]'
-      isError = true
-      break
-    case ROSFATAL:
-      prefix = '[FATAL]'
-      isError = true
-      break
-  }
+  logData = {}
+  logData[ROSDEBUG] = {prefix : '[DEBUG]', isError : false}
+  logData[ROSINFO] = {prefix : '[INFO]', isError : false}
+  logData[ROSWARN] = {prefix : '[WARN]', isError : true}
+  logData[ROSERROR] = {prefix : '[ERROR]', isError : true}
+  logData[ROSFATAL] = {prefix : '[FATAL]', isError : true}
+  console.log(message)
+  stamps = rosTimestamp()
+  consoleMsg = logData[logLevel].prefix + ' [' + stamps[1] + ']: ' + message
 
-  stamps = getTimestamp()
-  consoleMsg = prefix + ' [' + stamps[1] + ']: ' + message
-
-  // info goes to stdout, warn-error-fatal go to stderr
-  if (!isError) {
-    console.log(consoleMsg)
-  } else {
-    console.error(consoleMsg)
-  }
+  !logData[logLevel].isError
+    ? console.log(consoleMsg)
+    : console.error(consoleMsg)
   appendToConsole(consoleMsg, false)
-
-  // All log messages should go to the log file: currently goes to rosout.log
+  // log messages go to log file: currently rosout.log
   publishRosLog(logLevel, stamps[0], message)
 }
 
 // these functions copy the rospy logging functions
 function logDebug (message) {
-  // unlike rospy, currently the debug messages we generate will get published
+  // unlike rospy, (currently) the debug messages we generate will get published
   rosLog(ROSDEBUG, message)
 }
 function logInfo (message) {

--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -213,19 +213,22 @@ function getTimestamp () {
   let nsecs = Math.round(1000000000*(secs-secsFloored)) // nanoseconds since the previous second
 
   // return a dictionary for the ROS log and a float for the gui console
-  return [{secs : secsFloored, nsecs : nsecs}, secs]
+  return [{secs : secsFloored, nsecs : nsecs}, currentTime]
 }
 
 function logGeneric (logLevel, message) {
   stamps = getTimestamp()
   rosTimestamp = stamps[0] // dictionary for the ROS log message
-  consoleTimestamp = stamps[1].toFixed(3) // value for the console message
+  consoleTimestamp = stamps[1].toString().split(' ')[4] // hh:mm:ss from date object
 
+  // @TODO cedric can help me refactor this
   switch (logLevel) {
     case ROSDEBUG:
+      consoleMsg = "[DEBUG] " + '[' + consoleTimestamp + ']' + ': ' + message
+      console.log(consoleMsg)
+      appendToConsole(consoleMsg, false)
       break
     case ROSINFO:
-    //floor(timestamp.nsecs/1000, 2)
       consoleMsg = "[INFO] " + '[' + consoleTimestamp + ']' + ': ' + message
       console.log(consoleMsg)
       appendToConsole(consoleMsg, false)
@@ -247,6 +250,9 @@ function logGeneric (logLevel, message) {
       break
   }
 
+  // @TODO bonus if we can determine how to generate a log file for the gui
+  // rather than simply having it show up in rosout.log
+  // an attempt was made with the name and file elements in the log message
   ros_logger.publish(
     new ROSLIB.Message({
       // I'm only publishing the essentials. We could include more info if so desired
@@ -256,9 +262,9 @@ function logGeneric (logLevel, message) {
         // frame_id // string: probably only useful for tf
       },
       level : logLevel,
-      name : '/web_gui', // name of the node
-      msg : message
-      // file : // string: we could specify the js file that generated the log
+      // name : '/web_gui', // name of the node
+      msg : message,
+      // file : 'web_gui' // string: we could specify the js file that generated the log
       // function // string: we could specify the parent function that generated the log
       // line // uint32: we could specify the specific line of code that generated the log
       // topics // string[]: topic names that the node publishes

--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -233,7 +233,7 @@ function logGeneric (logLevel, message) {
       console.error(consoleMsg)
       appendToConsole(consoleMsg, false)
       break
-    case ROSERR:
+    case ROSERROR:
       consoleMsg = "[ERROR] " + '[' + timeVal + ']' + ': ' + message
       console.error(consoleMsg)
       appendToConsole(consoleMsg, false)
@@ -244,7 +244,7 @@ function logGeneric (logLevel, message) {
       appendToConsole(consoleMsg, false)
       break
   }
-  
+
   ros_logger.publish(
     new ROSLIB.Message({
       header : {

--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -204,20 +204,52 @@ function initRosWeb () {
 }
 
 /* functions used in main code */
-function logGeneric (logLevel, message) {
+
+function getTimestamp () {
   // next 3 lines taken from roslibjs action server example
   let currentTime = new Date()
   let secs = Math.floor(currentTime.getTime()/1000)
   let nsecs = Math.round(1000000000*(currentTime.getTime()/1000-secs))
 
+  return {secs : secs, nsecs : nsecs}
+}
+
+function logGeneric (logLevel, message) {
+  timestamp = getTimestamp()
+  timeVal = timestamp.secs + timestamp.nsecs/10e8
+  timeVal = timeVal.toFixed(3)
+
+  switch (logLevel) {
+    case ROSDEBUG:
+      break
+    case ROSINFO:
+    //floor(timestamp.nsecs/1000, 2)
+      consoleMsg = "[INFO] " + '[' + timeVal + ']' + ': ' + message
+      console.log(consoleMsg)
+      appendToConsole(consoleMsg, false)
+      break
+    case ROSWARN:
+      consoleMsg = "[WARN] " + '[' + timeVal + ']' + ': ' + message
+      console.error(consoleMsg)
+      appendToConsole(consoleMsg, false)
+      break
+    case ROSERR:
+      consoleMsg = "[ERROR] " + '[' + timeVal + ']' + ': ' + message
+      console.error(consoleMsg)
+      appendToConsole(consoleMsg, false)
+      break
+    case ROSFATAL:
+      consoleMsg = "[FATAL] " + '[' + timeVal + ']' + ': ' + message
+      console.error(consoleMsg)
+      appendToConsole(consoleMsg, false)
+      break
+  }
+  
   ros_logger.publish(
     new ROSLIB.Message({
       header : {
         // uint32 seq // sequence ID: consecutively increasing ID // seems to be automatic?
-        stamp : {
-          secs : secs,
-          nsecs : nsecs
-        }
+        stamp : timestamp
         // string frame_id // Frame this data is associated with // not relevant?
       },
       level : logLevel,
@@ -243,30 +275,16 @@ function logDebug (message) {
   // for the webpage maybe we can set it when we run initRosWeb()
   logGeneric(ROSDEBUG, message)
 }
-// @TODO console should output: "[level] [timestamp]: message"
-// where do I get the timestamp from? maybe put the logging inside logGeneric()
 function logInfo (message) {
-  consoleMsg = "[INFO] " + ': ' + message
-  console.error(consoleMsg)
-  appendToConsole(consoleMsg)
   logGeneric(ROSINFO, message)
 }
 function logWarn (message) {
-  consoleMsg = "[WARN] " + ': ' + message
-  console.error(consoleMsg)
-  appendToConsole(consoleMsg)
   logGeneric(ROSWARN, message)
 }
 function logErr (message) {
-  consoleMsg = "[ERROR] " + ': ' + message
-  console.error(consoleMsg)
-  appendToConsole(consoleMsg)
   logGeneric(ROSERROR, message)
 }
 function logFatal (message) {
-  consoleMsg = "[FATAL] " + ': ' + message
-  console.error(consoleMsg)
-  appendToConsole(consoleMsg)
   logGeneric(ROSFATAL, message)
 }
 

--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -244,7 +244,7 @@ function rosLog (logLevel, message) {
   logData[ROSWARN] = {prefix : '[WARN]', isError : true}
   logData[ROSERROR] = {prefix : '[ERROR]', isError : true}
   logData[ROSFATAL] = {prefix : '[FATAL]', isError : true}
-  console.log(message)
+
   stamps = rosTimestamp()
   consoleMsg = logData[logLevel].prefix + ' [' + stamps[1] + ']: ' + message
 

--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -212,14 +212,15 @@ function getTimestamp () {
   let secsFloored = Math.floor(secs) // seconds after truncating
   let nsecs = Math.round(1000000000*(secs-secsFloored)) // nanoseconds since the previous second
 
-  // return a dictionary for the ROS log and a float for the gui console
-  return [{secs : secsFloored, nsecs : nsecs}, currentTime]
+  // return a dictionary for the ROS log and a string for the gui console
+  let stampTime = currentTime.toString().split(' ')[4]
+  return [{secs : secsFloored, nsecs : nsecs}, stampTime]
 }
 
 function rosLog (logLevel, message) {
   stamps = getTimestamp()
   rosTimestamp = stamps[0] // dictionary for the ROS log message
-  consoleTimestamp = stamps[1].toString().split(' ')[4] // hh:mm:ss from date object
+  consoleTimestamp = stamps[1] // hh:mm:ss from date object
 
   // All log messages should go to the log file: currently goes to rosout.log
   // unlike rospy, currently debug messages we generate will get published


### PR DESCRIPTION
# Assignee Section
hi it me

## Description
Created js functions for logging to mimic rospy functions: logInfo, logWarn, logErr, logFatal
These all call rosLog which is assisted by rosTimeStamp and publishRosLog. A new publisher was created so that these functions all log to /rosout. In practice this means you'll find the logs in rosout.log on the computer which is running as ROS MASTER. The functions include the timestamp and the log level.

I've left some todos. Most of them are bonus features that aren't necessarily required. However one missing aspect is the logic for activating/deactivating logDebug as this would need some discussion on where we put the variable that handles this.

## How to Test:
- run the GUI with `rosgui` and `startgui`
- open a terminal and subscribe to `/rosout`: `rostopic echo /rosout`
- open the chrome console on the GUI and call the following functions one by one, passing in a string of your choosing as the parameter: logDebug, logInfo, logWarn, logErr, logFatal
- verify that messages with the format `[<loglevel>] [<timestamp>]: <message>` are shown:
  - in the chrome console, where debug/info are normal messages, warn is a warning, error and fatal are errors
  - in the GUI console, where they all show up simply as text
  - in the terminal, where they are shown with all of the parameters (seq, secs, nsecs, etc.)
  - at the end of `~/.ros/log/latest/rosout.log`. May require that you close roscore (and possibly all the other ros scripts) before the logfile is updated

## Future potential issues:
- [ ] determine how to generate a log file dedicated to the gui, since right now logs simply go to rosout.log whereas each python script (ex. ArmNode.py) gets its own log file
- [ ] consider implementing the [*args and **kwargs](http://wiki.ros.org/rospy/Overview/Logging) style functionality of the rospy functions
- [ ] have a variable/parameter somewhere to turn off DEBUG log level messages, in initRosWeb() for example. For reference, in rospy it's done with `rospy.init_node(nodeName, log_level=rospy.DEBUG)`
- [ ] for multiple operators, have some way of distinguishing logs generated from each specific operator's laptop/gui. Not sure where in the log message this would go... I've seen sometimes logs will have a "[Client 0]" show up in the messages, maybe it's related.

closes #211

Approval from at least one software team lead is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [x] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
