### PR TITLE
Scp image transfer 192

### DIFF
--- a/robot/rospackages/src/image_scp/config.py
+++ b/robot/rospackages/src/image_scp/config.py
@@ -1,0 +1,6 @@
+#enter host computer address
+host = "HOST_URL"
+#enter user name for host computer
+user = "USER NAME FOR HOST"
+#enter desired image path on host computer
+remote_path_1 = "PATH FOR IMAGE ON HOST COMPUTER"

--- a/robot/rospackages/src/image_scp/congif.py
+++ b/robot/rospackages/src/image_scp/congif.py
@@ -1,0 +1,6 @@
+from os import environ
+
+host = environ.get('login.encs.concordia.ca')
+user = environ.get('j_klimo')
+remote_path_1 = environ.get('/home/j/j_klimo/Documents/images')
+local = ('/home/jason/images/test1.png')

--- a/robot/rospackages/src/image_scp/image_scp.py
+++ b/robot/rospackages/src/image_scp/image_scp.py
@@ -1,15 +1,21 @@
 from paramiko import SSHClient
 from scp import SCPClient, SCPException
 import argparse
-from congif import (host, user, remote_path_1, local)
+from config import (host, user, remote_path_1)
+"""
+Script takes in the image as a command line argument.
+SSH keys need to be configured on both remote and local machine in order for the script to work.
+Host name, user nmae, and remote path are all imported from a config file. Update the information there 
+so that this script is portable .
 
+"""
 class remote_connection:
     def __init__(self, host, user, remote_path, file_name):
         self.host = host
         self.user = user
         self.remote_path = remote_path
         self.file_name = file_name
-
+#initiate the connection to the host machine
     def connect(self):
         self.client = SSHClient()
         self.client.load_system_host_keys()
@@ -27,6 +33,7 @@ class remote_connection:
             raise error
 
 if __name__ == "__main__":
+    #takes the image as a command line argument
     parser = argparse.ArgumentParser(description="the file that gets sent")
     parser.add_argument("image_file", action="append")
     args = parser.parse_args()
@@ -36,16 +43,3 @@ if __name__ == "__main__":
     sender.connect()
     sender.send_image(sender.file_name)
     sender.disconnect()
-
-
-    print(args.image_file[0])
-
-
-#ssh = SSHClient()
-#ssh.load_system_host_keys()
-#ssh.connect(hostname="login.encs.concordia.ca", username='user')
-
-#scp = SCPClient(ssh.get_transport())
-
-#scp.put('/test2.png', recursive=True,
- #       remo te_path='remotepath    e)

--- a/robot/rospackages/src/image_scp/image_scp.py
+++ b/robot/rospackages/src/image_scp/image_scp.py
@@ -1,16 +1,11 @@
 from paramiko import SSHClient
 from scp import SCPClient
-import argparse
-from getpass import getpass
-
-
-parser = argparse.ArgumentParser(description="ssh login name")
-parser.add_argument(
-
+from config import (host, user, remote_path_1, local)
 ssh = SSHClient()
 ssh.load_system_host_keys()
-ssh.connect('j_klimo@login.encs.concordia.ca')
+ssh.connect(hostname=host, username=user)
 
 scp = SCPClient(ssh.get_transport())
 
-scp.put('test', recursive=True, remote_path='/home/j/j_klimo/Documents/images')
+scp.put(local, recursive=True,
+        remote_path=remote_path_1)

--- a/robot/rospackages/src/image_scp/image_scp.py
+++ b/robot/rospackages/src/image_scp/image_scp.py
@@ -1,6 +1,7 @@
 from paramiko import SSHClient
-from scp import SCPClient
-#from congif import (host, user, remote_path_1, local)
+from scp import SCPClient, SCPException
+import argparse
+from congif import (host, user, remote_path_1, local)
 
 class remote_connection:
     def __init__(self, host, user, remote_path, file_name):
@@ -19,7 +20,25 @@ class remote_connection:
         self.client.close()
         self.scp.close()
 
+    def send_image(self, image):
+        try:
+            self.scp.put(image, recursive=True, remote_path=self.remote_path)
+        except SCPException as error:
+            raise error
 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="the file that gets sent")
+    parser.add_argument("image_file", action="append")
+    args = parser.parse_args()
+    to_transfer = args.image_file[0]
+
+    sender = remote_connection(host, user, remote_path_1, to_transfer)
+    sender.connect()
+    sender.send_image(sender.file_name)
+    sender.disconnect()
+
+
+    print(args.image_file[0])
 
 
 #ssh = SSHClient()
@@ -29,4 +48,4 @@ class remote_connection:
 #scp = SCPClient(ssh.get_transport())
 
 #scp.put('/test2.png', recursive=True,
- #       remote_path='remotepath    e)
+ #       remo te_path='remotepath    e)

--- a/robot/rospackages/src/image_scp/image_scp.py
+++ b/robot/rospackages/src/image_scp/image_scp.py
@@ -1,11 +1,32 @@
 from paramiko import SSHClient
 from scp import SCPClient
-from config import (host, user, remote_path_1, local)
-ssh = SSHClient()
-ssh.load_system_host_keys()
-ssh.connect(hostname=host, username=user)
+#from congif import (host, user, remote_path_1, local)
 
-scp = SCPClient(ssh.get_transport())
+class remote_connection:
+    def __init__(self, host, user, remote_path, file_name):
+        self.host = host
+        self.user = user
+        self.remote_path = remote_path
+        self.file_name = file_name
 
-scp.put(local, recursive=True,
-        remote_path=remote_path_1)
+    def connect(self):
+        self.client = SSHClient()
+        self.client.load_system_host_keys()
+        self.client.connect(hostname=self.host, username=self.user)
+        self.scp = SCPClient(self.client.get_transport())
+
+    def disconnect(self):
+        self.client.close()
+        self.scp.close()
+
+
+
+
+#ssh = SSHClient()
+#ssh.load_system_host_keys()
+#ssh.connect(hostname="login.encs.concordia.ca", username='user')
+
+#scp = SCPClient(ssh.get_transport())
+
+#scp.put('/test2.png', recursive=True,
+ #       remote_path='remotepath    e)

--- a/robot/rospackages/src/image_scp/image_scp.py
+++ b/robot/rospackages/src/image_scp/image_scp.py
@@ -1,0 +1,16 @@
+from paramiko import SSHClient
+from scp import SCPClient
+import argparse
+from getpass import getpass
+
+
+parser = argparse.ArgumentParser(description="ssh login name")
+parser.add_argument(
+
+ssh = SSHClient()
+ssh.load_system_host_keys()
+ssh.connect('j_klimo@login.encs.concordia.ca')
+
+scp = SCPClient(ssh.get_transport())
+
+scp.put('test', recursive=True, remote_path='/home/j/j_klimo/Documents/images')


### PR DESCRIPTION
# Assignee Section

## Description
Created a script to send images using scp. The file name is passed to the script as a command line argument. In order for the script to work, ssh keys need to be setup on both the local and the host computers. This only has to be done once for each computer, before running the script.

Host address, host username, and remote file path all are updated in the config.py file so that this information does not need to be changed in the script itself.  

[If applicable, include a list of main points]
- [ ] Image transfers between computers

closes #[192]

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [ ] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
