### PR TITLE
Fix environment setup 359

### DIFF
--- a/EnvironmentSetup.sh
+++ b/EnvironmentSetup.sh
@@ -2,7 +2,7 @@
 # Setup script which install the Space Concordia Robotics Software team's development environment.
 
 APPEND_TO_BASH="
-
+#\n\n ------ ROBOTICS SETTINGS ------
 #competition mode
 #export ROS_MASTER_URI=http://172.16.1.30:11311
 #export ROS_HOSTNAME=$USER
@@ -58,12 +58,9 @@ ROS_VERSION=$(rosversion -d)
 if [ $ROS_VERSION = "<unknown>" ] || [ $? != 0 ] # $? = 0 when previous command succeeds
 then
     echo "You do not have ROS installed, installing..."
-
-    wget https://raw.githubusercontent.com/ROBOTIS-GIT/robotis_tools/master/install_ros_kinetic.sh
-    chmod 755 ./install_ros_kinetic.sh
-    yes "" | bash ./install_ros_kinetic.sh
-    rm ./install_ros_kinetic.sh
-
+    
+    ./install_ros_kinetic.sh
+    
 	source ~/.bashrc
 
     sudo apt install ros-kinetic-rosbridge-suite -y

--- a/EnvironmentSetup.sh
+++ b/EnvironmentSetup.sh
@@ -2,7 +2,9 @@
 # Setup script which install the Space Concordia Robotics Software team's development environment.
 
 APPEND_TO_BASH="
-#\n\n ------ ROBOTICS SETTINGS ------
+
+
+#------ ROBOTICS SETTINGS ------
 #competition mode
 #export ROS_MASTER_URI=http://172.16.1.30:11311
 #export ROS_HOSTNAME=$USER

--- a/EnvironmentSetup.sh
+++ b/EnvironmentSetup.sh
@@ -59,7 +59,7 @@ if [ $ROS_VERSION = "<unknown>" ] || [ $? != 0 ] # $? = 0 when previous command 
 then
     echo "You do not have ROS installed, installing..."
     
-    ./install_ros_kinetic.sh
+    bash install_ros_kinetic.sh
     
 	source ~/.bashrc
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ Running `pytest` without doing `python setup.py develop` will give a ModuleNotFo
 To deactivate virtualenv, run `deactivate`.
 ### Install [ROS-Kinetic](http://wiki.ros.org/kinetic)
 ```
-wget https://raw.githubusercontent.com/ROBOTIS-GIT/robotis_tools/master/install_ros_kinetic.sh
-chmod 755 ./install_ros_kinetic.sh
 bash ./install_ros_kinetic.sh
 ```
 To see exactly what happened during the installation of ROS-Kinetic, you can read the script file located in which ever directory it was downloaded in. Your `~/.bashrc` file was modified, and so to make use of the new changes, **you should restart your terminal**.

--- a/install_ros_kinetic.sh
+++ b/install_ros_kinetic.sh
@@ -1,0 +1,65 @@
+#!bin/bash
+# Apache License 2.0
+# Copyright (c) 2017, ROBOTIS CO., LTD.
+
+echo "[Set the target OS, ROS version"
+name_os_version=${name_os_version:="xenial"}
+name_ros_version=${name_ros_version:="kinetic"}
+
+echo "[Update the package lists and upgrade them]"
+sudo apt-get update -y
+sudo apt-get upgrade -y
+
+echo "[Install build environment, the chrony, ntpdate and set the ntpdate]"
+sudo apt-get install -y chrony ntpdate build-essential
+sudo ntpdate ntp.ubuntu.com
+
+echo "[Add the ROS repository]"
+if [ ! -e /etc/apt/sources.list.d/ros-latest.list ]; then
+  sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu ${name_os_version} main\" > /etc/apt/sources.list.d/ros-latest.list"
+fi
+
+echo "[Download the ROS keys]"
+roskey=`apt-key list | grep "Open Robotics"`
+if [ -z "$roskey" ]; then
+  sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+fi
+
+echo "[Check the ROS keys]"
+roskey=`apt-key list | grep "Open Robotics"`
+if [ -n "$roskey" ]; then
+  echo "[ROS key exists in the list]"
+else
+  echo "[Failed to receive the ROS key, aborts the installation]"
+  exit 0
+fi
+
+echo "[Update the package lists and upgrade them]"
+sudo apt-get update -y
+sudo apt-get upgrade -y
+
+echo "[Install the ros-desktop-full and all rqt plugins]"
+sudo apt-get install -y ros-$name_ros_version-desktop-full ros-$name_ros_version-rqt-*
+
+echo "[Initialize rosdep]"
+sudo sh -c "rosdep init"
+rosdep update
+
+echo "[Environment setup and getting rosinstall]"
+source /opt/ros/$name_ros_version/setup.sh
+sudo apt-get install -y python-rosinstall
+
+echo "[Set the ROS evironment]"
+sh -c "echo '#\n\n ------ POST ROS INSTALLATION ------'" >> ~/.bashrc"
+sh -c "echo \"alias eb='nano ~/.bashrc'\" >> ~/.bashrc"
+sh -c "echo \"alias sb='source ~/.bashrc'\" >> ~/.bashrc"
+sh -c "echo \"alias gs='git status'\" >> ~/.bashrc"
+sh -c "echo \"alias gp='git pull'\" >> ~/.bashrc"
+
+sh -c "echo \"export ROS_MASTER_URI=http://localhost:11311\" >> ~/.bashrc"
+sh -c "echo \"export ROS_HOSTNAME=localhost\" >> ~/.bashrc"
+
+source $HOME/.bashrc
+
+echo "[Complete!!!]"
+exit 0

--- a/install_ros_kinetic.sh
+++ b/install_ros_kinetic.sh
@@ -2,6 +2,9 @@
 # Apache License 2.0
 # Copyright (c) 2017, ROBOTIS CO., LTD.
 
+# This script is adapted to be the Space Concordia Robotics Division needs
+# Changes were made to not set up catkin_ws, update the bashrc edits, and remove the confirmation check
+
 echo "[Set the target OS, ROS version"
 name_os_version=${name_os_version:="xenial"}
 name_ros_version=${name_ros_version:="kinetic"}


### PR DESCRIPTION
# Assignee Section

## Description
Fixes a serious ROS/Catkin configuration error caused by the third-party ROS install script `install_ros_kinetic.sh`. 
The fix involves removing the erroneous addition of some commands to the `.bash_rc` and also removing the catkin workspace setup since we have our own process. 

- Removed bad sourcing
- Fixed catkin workspace setup

### Steps for Testing

1. Either setup a fresh VM or create a new user account in Ubuntu
2. Run the setup script: `./EnvironmentSetup.sh`
3. Check if the GUI works: `rosgui` in one terminal followed by `startgui` in another, visit `localhost:5000` in chrome.

closes #359

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [x] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
