### PR TITLE
Fix syntax error on pds page

### DIFF
--- a/robot/basestation/static/js/pages/pds.js
+++ b/robot/basestation/static/js/pages/pds.js
@@ -72,7 +72,7 @@ $(document).ready(() => {
           .includes('PDS')
       ) {
       requestTask(
-          PDS_LISTENER_TASK
+          PDS_LISTENER_TASK,
           STATUS_START,
           function (msgs) {
             if (msgs[0]) {


### PR DESCRIPTION
# Assignee Section

## Description
Fixed a syntax error on the PDS page

### Steps for Testing
1) Start the GUI with `rosgui` and `startgui`
2) Open the PDS page and ensure there is no syntax error
3) Profit?

closes #375 

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [ ] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
