### PR TITLE
Fix issue tag duplication 390

### DIFF
--- a/commit_message_hook.py
+++ b/commit_message_hook.py
@@ -22,5 +22,5 @@ def add_commit_issue_num(branch_name):
 if __name__ == '__main__':
     branch_name = get_branch_name()
     #If there is already a commit message this hook is disabled
-    if not is_excluded_branch(branch_name, excluded_branches) and sys.argv[2] != 'commit' and read_from_file(sys.argv[1], 5) != '#[':
+    if not is_excluded_branch(branch_name, excluded_branches) and sys.argv[2] != 'commit' and read_from_file(sys.argv[1], 2) != '#[':
         add_commit_issue_num(branch_name)

--- a/commit_message_hook.py
+++ b/commit_message_hook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import robot.basestation.app as app
-from robot.util.utils import run_shell, append_to_file
+from robot.util.utils import run_shell, append_to_file, read_from_file
 from branch_name_verification_hook import is_excluded_branch, get_issue_num, get_branch_name, excluded_branches
 import re
 import sys
@@ -22,5 +22,5 @@ def add_commit_issue_num(branch_name):
 if __name__ == '__main__':
     branch_name = get_branch_name()
     #If there is already a commit message this hook is disabled
-    if not is_excluded_branch(branch_name, excluded_branches) and sys.argv[2] != "commit":
+    if not is_excluded_branch(branch_name, excluded_branches) and sys.argv[2] != 'commit' and read_from_file(sys.argv[1], 5) != '#[':
         add_commit_issue_num(branch_name)

--- a/commit_message_hook.py
+++ b/commit_message_hook.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 import robot.basestation.app as app
-from robot.util.utils import run_shell, append_to_file, read_from_file
+from robot.util.utils import run_shell, append_to_file
 from branch_name_verification_hook import is_excluded_branch, get_issue_num, get_branch_name, excluded_branches
 import re
 import sys
+import os
+from os import path
 
 def add_commit_issue_num(branch_name):
     """
@@ -21,6 +23,6 @@ def add_commit_issue_num(branch_name):
 
 if __name__ == '__main__':
     branch_name = get_branch_name()
-    #If there is already a commit message this hook is disabled
-    if not is_excluded_branch(branch_name, excluded_branches) and read_from_file(sys.argv[1], 2) != '[#':
+    #If there is already a commit message or if cherry-picking, this hook is disabled
+    if not is_excluded_branch(branch_name, excluded_branches) and sys.argv[2] != 'commit' and not path.exists('.git/CHERRY_PICK_HEAD'):
         add_commit_issue_num(branch_name)

--- a/commit_message_hook.py
+++ b/commit_message_hook.py
@@ -22,5 +22,5 @@ def add_commit_issue_num(branch_name):
 if __name__ == '__main__':
     branch_name = get_branch_name()
     #If there is already a commit message this hook is disabled
-    if not is_excluded_branch(branch_name, excluded_branches) and sys.argv[2] != 'commit' and read_from_file(sys.argv[1], 2) != '#[':
+    if not is_excluded_branch(branch_name, excluded_branches) and read_from_file(sys.argv[1], 2) != '[#':
         add_commit_issue_num(branch_name)

--- a/commit_message_hook.py
+++ b/commit_message_hook.py
@@ -23,6 +23,6 @@ def add_commit_issue_num(branch_name):
 
 if __name__ == '__main__':
     branch_name = get_branch_name()
-    #If there is already a commit message or if cherry-picking, this hook is disabled
+    # If there is already a commit message or if cherry-picking, this hook is disabled
     if not is_excluded_branch(branch_name, excluded_branches) and sys.argv[2] != 'commit' and not path.exists('.git/CHERRY_PICK_HEAD'):
         add_commit_issue_num(branch_name)

--- a/robot/util/utils.py
+++ b/robot/util/utils.py
@@ -45,4 +45,4 @@ def append_to_file(filename, text):
 def read_from_file(filename, num_char):
     with open(filename, 'r+') as f:
         f.seek(0, 0)
-        return f.read(2)
+        return f.read(num_char)

--- a/robot/util/utils.py
+++ b/robot/util/utils.py
@@ -41,3 +41,8 @@ def append_to_file(filename, text):
         content = f.read()
         f.seek(0, 0)
         f.write(text.rstrip('\r\n') + content)
+
+def read_from_file(filename, num_char):
+    with open(filename, 'r+') as f:
+        f.seek(0, 0)
+        return f.read(2)

--- a/robot/util/utils.py
+++ b/robot/util/utils.py
@@ -41,8 +41,3 @@ def append_to_file(filename, text):
         content = f.read()
         f.seek(0, 0)
         f.write(text.rstrip('\r\n') + content)
-
-def read_from_file(filename, num_char):
-    with open(filename, 'r+') as f:
-        f.seek(0, 0)
-        return f.read(num_char)


### PR DESCRIPTION
# Assignee Section

## Description
Git commit message hook now checks for cherry-pick file that is present in '.git' folder during cherry picking. In order to avoid duplicating the issue number in the commit message. 

### Steps for Testing
1. Run `cp commit_message_hook.py .git/hooks/prepare-commit-msg` on 'fix-issue-tag-duplication-390' to cherry pick any older commit in branch, without pushing. (Use `git log` to view older commit hashes)
2. Use `git cherry-pick 613f09a` and run `git commit --allow-empty` to allow an empty commit. This still allows us to test if the hook will append the issue number to the message or not.
3. Check that the issue number wasn't duplicated in the commit message with `git commit --amend`.
4. Use `git reset HEAD^` to undo the commit. There shouldn't be any changes brought from the cherry pick if you used '613f09a', but if there are use `git stash` and `git stash drop` to delete the changes brought over.
5. Create a dummy file and commit it without pushing it, with a commit message of your choosing.
6. Ensure that the issue number was appended to the commit message with `git commit --amend`.
7. Use `git reset HEAD^` to undo the commit, then delete the dummy file.

closes #390

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [ ] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
