### PR TITLE
Fix Twisted alerts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: trusty
 language: python
 before_install:
     # Taken from this tutorial https://github.com/newdigate/teensy-blink

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: trusty # Ubuntu 14, Xenial (Ubuntu 16) seems to crash python...
+dist: xenial
 language: python
 before_install:
     # Taken from this tutorial https://github.com/newdigate/teensy-blink

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
   - mv ~/Arduino/libraries/SparkFun_I2C_GPS_Arduino_Library-$SPARKFUN_I2C_VERSION ~/Arduino/libraries/SparkFun_I2C_GPS_Reading_and_Control
   - pip install -r requirements.txt
   - pip install -e .
+  - python setup.py develop
 script:
   - cd robot/rover/build
   - cmake ..

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,6 @@ tornado==6.0.2
 bson==0.5.8
 pymongo==3.8.0
 image==1.5.27
+attrs==18.1.0
 Twisted==20.3.0
 pygame==1.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,6 @@ tornado==6.0.2
 bson==0.5.8
 pymongo==3.8.0
 image==1.5.27
-attrs==19.2.0
+attrs==19.1.0
 Twisted==20.3.0
 pygame==1.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 atomicwrites==1.1.5
-attrs==18.1.0
 cycler==0.10.0
 empy==3.3.2
 kiwisolver==1.0.1
@@ -25,5 +24,5 @@ tornado==6.0.2
 bson==0.5.8
 pymongo==3.8.0
 image==1.5.27
-Twisted==19.7.0
+Twisted==20.3.0
 pygame==1.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,6 @@ tornado==6.0.2
 bson==0.5.8
 pymongo==3.8.0
 image==1.5.27
-attrs==18.1.0
+attrs==19.2.0
 Twisted==20.3.0
 pygame==1.9.6


### PR DESCRIPTION
# Assignee Section

## Description
Updates Twisted dependency to remove version alert.
Removes a dependency as twisted reinstalls it with the latest version anyways.

### Steps for Testing
1. from root of repo, deactivate venv with `deactivate`
2. `rm -rf venv`
3. Use manual setup to:
    a. create virtualenv: ```virtualenv -p `which python3.6` venv```
    b. activate venv: `. venv/bin/activate`
    b. install dependencies: `pip install -r requirements.txt -r requirements-dev.txt`
    c. setup setuptools: `python setup.py develop`
4. confirm that gui runs: `rosgui`, `startgui`, visit `localhost:5000`
5. confirm that unit tests run: `pytest`

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [x] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
