### PR TITLE
Move aliases

### DIFF
--- a/install_ros_kinetic.sh
+++ b/install_ros_kinetic.sh
@@ -63,6 +63,25 @@ sh -c "echo \"alias cm='cw && catkin_make'\" >> ~/.bashrc"
 sh -c "echo \"\nexport ROS_MASTER_URI=http://localhost:11311\" >> ~/.bashrc"
 sh -c "echo \"export ROS_HOSTNAME=localhost\" >> ~/.bashrc"
 
+
+echo 'ROBOTICS_WS="/home/$USER/Programming/robotics-prototype"
+BASE="$ROBOTICS_WS/robot/basestation"
+ROVER="$ROBOTICS_WS/robot/rover"
+ROSPACKAGES="$ROBOTICS_WS/robot/rospackages"
+BASH_A="~/.bash_aliases"
+NANORC="~/.nanorc"
+
+# general shortcuts
+alias ..="cd .."
+alias b="cd -"
+alias robotics="cd $ROBOTICS_WS"
+alias base="cd $BASE"
+alias rover="cd $ROVER"
+alias arm="cd $ROVER/ArmDriverUnit"
+alias wheels="cd $ROVER/MobilePlatform"
+alias rostings="cd $ROSPACKAGES"
+alias mcunode="cd $ROSPACKAGES/src/mcu_control/scripts"' >> ~/.bash_aliases
+
 source $HOME/.bashrc
 
 echo "[Complete!!!]"

--- a/robot/basestation/config/.bash_aliases
+++ b/robot/basestation/config/.bash_aliases
@@ -1,27 +1,4 @@
 #!/usr/bin/env bash
-ROBOTICS_WS="/home/$USER/Programming/robotics-prototype"
-BASE="$ROBOTICS_WS/robot/basestation"
-ROVER="$ROBOTICS_WS/robot/rover"
-ROSPACKAGES="$ROBOTICS_WS/robot/rospackages"
-BASH_A="~/.bash_aliases"
-NANORC="~/.nanorc"
-
-# general shortcuts
-alias ..="cd .."
-alias b="cd -"
-alias robotics="cd $ROBOTICS_WS"
-alias base="cd $BASE"
-alias rover="cd $ROVER"
-alias arm="cd $ROVER/ArmDriverUnit"
-alias wheels="cd $ROVER/MobilePlatform"
-alias rostings="cd $ROSPACKAGES"
-alias mcunode="cd $ROSPACKAGES/src/mcu_control/scripts"
-
-# edit thyself
-alias editalius="nano $BASH_A"
-alias alius=". $BASH_A"
-alias editnani="nano $NANORC"
-alias nani=". $NANORC"
 
 # to start the gui
 alias updateEnv="bash $BASE/env.sh >| $BASE/static/js/env.js"


### PR DESCRIPTION
# Assignee Section

## Description
I moved the customizable aliases to the install script so that they are included in ~/.bash_aliases upon installation.
I removed those aliases from their original location so they are not duplicated.
I remove dumb aliases b/c they are dumb... Add them to your own files if you actually use them.

### Steps for Testing
1. Create an executable with this:
```
echo 'ROBOTICS_WS="/home/$USER/Programming/robotics-prototype"
BASE="$ROBOTICS_WS/robot/basestation"
ROVER="$ROBOTICS_WS/robot/rover"
ROSPACKAGES="$ROBOTICS_WS/robot/rospackages"
BASH_A="~/.bash_aliases"
NANORC="~/.nanorc"

# general shortcuts
alias ..="cd .."
alias b="cd -"
alias robotics="cd $ROBOTICS_WS"
alias base="cd $BASE"
alias rover="cd $ROVER"
alias arm="cd $ROVER/ArmDriverUnit"
alias wheels="cd $ROVER/MobilePlatform"
alias rostings="cd $ROSPACKAGES"
alias mcunode="cd $ROSPACKAGES/src/mcu_control/scripts"' >> ~/.bash_aliases
```

2. Run it and verify output in ~/.bash_aliases
3. Check the edited files to make sure you know what happened.

closes #406 

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [ ] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
