### PR TITLE
Cmake upload teensy 382

### DIFF
--- a/robot/rover/CMakeLists.txt
+++ b/robot/rover/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5.0)
+
 set(CMAKE_SYSTEM_PROCESSOR arm)
 include(ExternalProject)
 
@@ -19,6 +20,8 @@ set(ARDUINO_EXTERNAL_LIB /home/$ENV{USER}/Arduino/libraries)
 set(ARM_TOOLS ${ARDUINO_PATH}/hardware/tools)
 set(ARM_LIB ${ARM_TOOLS}/arm/arm-none-eabi/lib)
 set(ARM_GCC_OBJCOPY ${ARM_TOOLS}/arm/bin/arm-none-eabi-objcopy)
+set(TEENSY_LOADER_CLI ${ARM_TOOLS}/teensy_loader_cli)
+
 
 #given a name, will check if the library exists in the proper directory, otherwise run install_arduino_libraries.sh which will install it
 function(checkLibraries lib_name lib_version lib_url)
@@ -167,7 +170,7 @@ foreach(path ${INOFILES})
  get_filename_component(project_dir ${path} DIRECTORY)
  get_filename_component(name ${path} NAME_WE)
  
- #creates a command which runs a few batch commands to delete the current subproject. 
+ #creates a command which runs a few bash commands to delete the current subproject. 
  #These are useless on their own and need to be attached to a target to work 
  add_custom_command(
  OUTPUT ${name}_cleanup
@@ -176,8 +179,7 @@ foreach(path ${INOFILES})
  )
 
  set(Project_Name ${name})
- #the continues are mainly for code that isn't exactly needed (test code and such) or random example code
- #that will inevitable get refactored. Its gonna skip over them since they arent needed for the build   
+ 
  if(${name} STREQUAL "Arm")
  set(PROJECT_LIBRARIES  Servo)
 
@@ -189,19 +191,19 @@ foreach(path ${INOFILES})
  elseif(${name} STREQUAL "MobilePlatform")
  
  set(PROJECT_LIBRARIES Servo Wire LSM303 ArduinoBlue SparkFunGPS SoftwareSerial)
- set(EXTERNAL_LIBARRIES_INCLUDE_DIRS ${LSM303_PATH} ${ARDUINO_BLUE_PATH} ${SPARKFUN_GPS_PATH} )
+ set(EXTERNAL_LIBRARIES_INCLUDE_DIRS ${LSM303_PATH} ${ARDUINO_BLUE_PATH} ${SPARKFUN_GPS_PATH} )
 
  elseif(${name} STREQUAL "PidController")
  set(PROJECT_LIBRARIES Adafruit Encoder Wire Servo)
- set(EXTERNAL_LIBARRIES_INCLUDE_DIRS ${ADAFRUIT_PATH})
+ set(EXTERNAL_LIBRARIES_INCLUDE_DIRS ${ADAFRUIT_PATH})
 
  endif()
  
  #write the template with the child project name in child project directory and execute the CMakeLists.txt file in there when created
  configure_file(CMakeTemplate.txt.in ${CMAKE_CURRENT_SOURCE_DIR}/${project_dir}/CMakeLists.txt @ONLY) 
  add_subdirectory(${project_dir}) 
-
-endforeach()
+ 
+ endforeach()
 
  #this builds a target, which can be called be built from the command line to delete ALL generated files, and directories. 
  #the command is cmake --build . --target clean

--- a/robot/rover/CMakeLists.txt
+++ b/robot/rover/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5.0)
 
 set(CMAKE_SYSTEM_PROCESSOR arm)
+set(MCU mk66fx1m0)
+
 include(ExternalProject)
 
 
@@ -122,7 +124,7 @@ set(ARM_GCC_C_FLAGS -O2 -g -ffunction-sections -nostdlib -MMD -mthumb -mcpu=cort
 set(ARM_GXX_FLAGS -O2 -g -ffunction-sections -nostdlib -MMD -mthumb -fno-exceptions -fpermissive -felide-constructors -std=gnu++14 -Wno-error=narrowing -fno-rtti -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant)
 
 #linker flags, note even c++ projects link using gcc, since we are using the -lstdc++ flag -> from Teensyduino
-set(ARM_GCC_LINKER_FLAGS "-O2 -Wl,--gc-sections,--relax,--defsym=__rtc_localtime=1584728951 -T${TEENSY_CORE}/teensy3/mk66fx1m0.ld -lstdc++ -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant")
+set(ARM_GCC_LINKER_FLAGS "-O2 -Wl,--gc-sections,--relax,--defsym=__rtc_localtime=1584728951 -T${TEENSY_CORE}/teensy3/${MCU}.ld -lstdc++ -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -fsingle-precision-constant")
 
 #S FILES - compiled with gcc
 add_library(teensycore_s  OBJECT ${TEENSY_CORE_S_FILES})

--- a/robot/rover/CMakeLists.txt
+++ b/robot/rover/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEENSY_LIB ${ARDUINO_PATH}/hardware/teensy/avr/libraries)
 set(ARDUINO_EXTERNAL_LIB /home/$ENV{USER}/Arduino/libraries)
 set(ARM_TOOLS ${ARDUINO_PATH}/hardware/tools)
 set(ARM_LIB ${ARM_TOOLS}/arm/arm-none-eabi/lib)
+set(ARM_GCC_OBJCOPY ${ARM_TOOLS}/arm/bin/arm-none-eabi-objcopy)
 
 #given a name, will check if the library exists in the proper directory, otherwise run install_arduino_libraries.sh which will install it
 function(checkLibraries lib_name lib_version lib_url)
@@ -185,7 +186,7 @@ foreach(path ${INOFILES})
  elseif(${name} STREQUAL "PDS")
  continue()
  
-elseif(${name} STREQUAL "MobilePlatform")
+ elseif(${name} STREQUAL "MobilePlatform")
  
  set(PROJECT_LIBRARIES Servo Wire LSM303 ArduinoBlue SparkFunGPS SoftwareSerial)
  set(EXTERNAL_LIBARRIES_INCLUDE_DIRS ${LSM303_PATH} ${ARDUINO_BLUE_PATH} ${SPARKFUN_GPS_PATH} )
@@ -212,7 +213,6 @@ endforeach()
  DEPENDS Arm_cleanup
  DEPENDS MobilePlatform_cleanup
  DEPENDS PidController_cleanup
- DEPENDS EncoderFunc_cleanup
  DEPENDS science_cleanup
  )
 

--- a/robot/rover/CMakeTemplate.txt.in
+++ b/robot/rover/CMakeTemplate.txt.in
@@ -20,20 +20,20 @@ endif()
 
 configure_file(${PROJECT_NAME}.ino ${PROJECT_NAME}.ino.cpp)
 
-add_executable(${PROJECT_NAME} ${PROJECT_NAME}.ino.cpp)
-target_compile_options(${PROJECT_NAME} PUBLIC ${ARM_GXX_FLAGS})
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(${PROJECT_NAME} PRIVATE @EXTERNAL_LIBRARIES_INCLUDE_DIRS@)
+add_executable(${PROJECT_NAME}_EXE ${PROJECT_NAME}.ino.cpp)
+target_compile_options(${PROJECT_NAME}_EXE PUBLIC ${ARM_GXX_FLAGS})
+target_include_directories(${PROJECT_NAME}_EXE PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${PROJECT_NAME}_EXE PRIVATE @EXTERNAL_LIBRARIES_INCLUDE_DIRS@)
 
 set_target_properties(
-${PROJECT_NAME} PROPERTIES 
+${PROJECT_NAME}_EXE PROPERTIES 
 LINKER_LANGUAGE C 
 LINK_FLAGS ${ARM_GCC_LINKER_FLAGS} 
 OUTPUT_NAME ${PROJECT_NAME}.elf
 )
  
 target_link_libraries(
-${PROJECT_NAME} 
+${PROJECT_NAME}_EXE 
 @PROJECT_LIBRARIES@
 $<$<BOOL:${${PROJECT_NAME}_user_sources}>:${PROJECT_NAME}_user> 
 teensycore
@@ -41,7 +41,15 @@ teensycore
 ) 
 
 add_custom_command(
-TARGET ${PROJECT_NAME}
+TARGET ${PROJECT_NAME}_EXE
 POST_BUILD
 COMMAND ${ARM_GCC_OBJCOPY} -O ihex -R.eeprom ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.elf ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.hex 
 )
+add_custom_command(OUTPUT ${PROJECT_NAME}_upload_command
+COMMAND ${TEENSY_LOADER_CLI} --mcu=${MCU} -s -v ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.hex 
+DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.hex 
+)
+
+add_custom_target(${PROJECT_NAME}
+DEPENDS ${PROJECT_NAME}_upload_command
+)	

--- a/robot/rover/CMakeTemplate.txt.in
+++ b/robot/rover/CMakeTemplate.txt.in
@@ -40,3 +40,9 @@ $<$<BOOL:${${PROJECT_NAME}_user_sources}>:${PROJECT_NAME}_user>
 teensycore
 -lm
 ) 
+
+add_custom_command(
+TARGET ${PROJECT_NAME}
+POST_BUILD
+COMMAND ${ARM_GCC_OBJCOPY} -O ihex -R.eeprom ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.elf ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.hex 
+)

--- a/robot/rover/CMakeTemplate.txt.in
+++ b/robot/rover/CMakeTemplate.txt.in
@@ -23,8 +23,7 @@ configure_file(${PROJECT_NAME}.ino ${PROJECT_NAME}.ino.cpp)
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.ino.cpp)
 target_compile_options(${PROJECT_NAME} PUBLIC ${ARM_GXX_FLAGS})
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_include_directories(${PROJECT_NAME} PRIVATE @EXTERNAL_LIBARRIES_INCLUDE_DIRS@)
+target_include_directories(${PROJECT_NAME} PRIVATE @EXTERNAL_LIBRARIES_INCLUDE_DIRS@)
 
 set_target_properties(
 ${PROJECT_NAME} PROPERTIES 

--- a/robot/rover/config/.bash_aliases
+++ b/robot/rover/config/.bash_aliases
@@ -16,9 +16,12 @@ alias arm="cd $ROVER/ArmDriverUnit"
 alias wheels="cd $ROVER/MobilePlatform"
 alias rostings="cd $ROSPACKAGES"
 alias mcunode="cd $ROSPACKAGES/src/mcu_control/scripts"
+alias upload="cmake --build $ROVER/build --target "
+alias cmake_clean="cmake --build $ROVER/build --target cleanup && rm -rf $ROVER/build"
 
 # edit thyself
 alias editalius="nano $BASH_A"
 alias alius=". $BASH_A"
 alias editnani="nano $NANORC"
 alias nani=". $NANORC"
+

--- a/robot/rover/install_teensy_loader_cli.sh
+++ b/robot/rover/install_teensy_loader_cli.sh
@@ -26,3 +26,6 @@ else
 	rm -rf teensy_loader_cli.zip teensy_loader_cli-master
 
 fi 
+
+
+

--- a/robot/rover/install_teensy_loader_cli.sh
+++ b/robot/rover/install_teensy_loader_cli.sh
@@ -1,30 +1,24 @@
 #!/bin/bash
 
+
 if [ -f "/etc/udev/rules.d/49-teensy.rules" ]; then
-	echo "Permissions file already exists"
+	echo "teensy rules already installed"
 else
-	echo "Downloading permissions..."
-	wget -P /etc/udev/rules.d/ "https://www.pjrc.com/teensy/49-teensy.rules" 
+	echo "Downloading teensy rules..."
+	sudo wget -P /etc/udev/rules.d/ "https://www.pjrc.com/teensy/49-teensy.rules" 
 fi 
 
+	sudo apt install --no-upgrade libusb-dev
 
-if  dpkg --get-selections | grep -q "^$pkg[[:space:]]*libusb-dev$" >/dev/null; then
-	echo "Installing libsub-dev"
-	apt-get install libusb-dev;
+if [ -f "${ARDUINO_PATH}"/hardware/tools/teensy_loader_cli ]; then
+	echo "Teensy Loader CLI already installed"
 else
-	echo "Libusb-dev already installed"
-fi
-
-if [ -e "${ARDUINO_PATH}"/hardware/tools/teensy_loader_cli ]; then
-	echo "Teensy loader CLI already installed"
-else
-	echo "Installing Teensy Loader CLI" 
+	echo "Installing Teensy Loader CLI..." 
 	curl https://github.com/PaulStoffregen/teensy_loader_cli/archive/master.zip -L -o teensy_loader_cli.zip
 	unzip -q teensy_loader_cli.zip 
 	make -s -C teensy_loader_cli-master
 	mv teensy_loader_cli-master/teensy_loader_cli "${ARDUINO_PATH}"/hardware/tools
 	rm -rf teensy_loader_cli.zip teensy_loader_cli-master
-
 fi 
 
 

--- a/robot/rover/install_teensy_loader_cli.sh
+++ b/robot/rover/install_teensy_loader_cli.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ -f "/etc/udev/rules.d/49-teensy.rules" ]; then
+	echo "Permissions file already exists"
+else
+	echo "Downloading permissions..."
+	wget -P /etc/udev/rules.d/ "https://www.pjrc.com/teensy/49-teensy.rules" 
+fi 
+
+
+if  dpkg --get-selections | grep -q "^$pkg[[:space:]]*libusb-dev$" >/dev/null; then
+	echo "Installing libsub-dev"
+	apt-get install libusb-dev;
+else
+	echo "Libusb-dev already installed"
+fi
+
+if [ -e "${ARDUINO_PATH}"/hardware/tools/teensy_loader_cli ]; then
+	echo "Teensy loader CLI already installed"
+else
+	echo "Installing Teensy Loader CLI" 
+	curl https://github.com/PaulStoffregen/teensy_loader_cli/archive/master.zip -L -o teensy_loader_cli.zip
+	unzip -q teensy_loader_cli.zip 
+	make -s -C teensy_loader_cli-master
+	mv teensy_loader_cli-master/teensy_loader_cli "${ARDUINO_PATH}"/hardware/tools
+	rm -rf teensy_loader_cli.zip teensy_loader_cli-master
+
+fi 


### PR DESCRIPTION
# Assignee Section

## Description
Using CMake, upload the compiled C++ to a Teensy board, using the Teensy Loader CLI program from https://github.com/PaulStoffregen/teensy_loader_cli . It uploads one project at a time, although since the Rover uses 3 Teensys, this can easily be expanded to upload everything at once. Requires a Teensy board to test.

### Steps for Testing
1. Ensure that `rover/config/.bash_aliases` is being sourced, preferably from `~/.bashrc`
2. Go to `robot/rover`, and run `./install_teensy_loader_cli.sh`
3. In `rover`, run `mkdir build && cd build`
4. `cmake ..`
5. `make`
6. Connect your Teensy3.6 board to your computer via usb

#### Now we test every project individually, you can also use a serial monitor to verify data transmission

7. `upload science`
8. `upload Arm`
9. `upload MobilePlatform`

#### You can remove everything that was generated by cmake with
10. `cmake_clean`

closes #382

The approval from all software team leads is necessary before merging. 

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [x] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
