### PR TITLE
[#420] Fix identification issue

### DIFF
--- a/robot/rospackages/src/mcu_control/scripts/SerialUtil.py
+++ b/robot/rospackages/src/mcu_control/scripts/SerialUtil.py
@@ -25,7 +25,7 @@ def get_serial():
 
 def attempt_usb(mcuName):
     startListening = time.time() 
-    ser.write(str.encode(mcuName + ' who\n'))
+    ser.write(str.encode('who\n'))
     while (time.time()-startListening < COMM_TIMEOUT):
         if ser.in_waiting:
             response = ser.readline().decode()
@@ -42,7 +42,7 @@ def attempt_usb(mcuName):
 
 def attempt_uart(mcuName):
     startListening = time.time()
-    ser.write(str.encode(mcuName + ' who\n'))
+    ser.write(str.encode('who\n'))
     while (time.time()-startListening < COMM_TIMEOUT):
         if ser.in_waiting:
             dat=''


### PR DESCRIPTION
# Assignee Section

## Description
The ROS MCU nodes would always claim they found the microcontrollers. Even if it clearly should not have happened

### Steps for Testing

 FOR EACH in [Science, Rover, Arm], upload the code on a teensy.
 For each node in [Science, Rover, Arm]. Launch the node, make sure that the MCU only identifies when there's the correct code
`rosrun mcunode $nodeNode.py`
End For
END FOR

Further, it should be verified with an Arduino that it also works with the PDS

closes #420
The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [x] Local Test Performed Successfully
- [x] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
