### PR TITLE
[#426] Add cmake files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ rover_stream
 stream_images
 *.swp
 emails.txt
+robot/rover/Arm/CMakeLists.txt
+robot/rover/MobilePlatform/CMakeLists.txt
+robot/rover/PidController/CMakeLists.txt
+robot/rover/science/CMakeLists.txt


### PR DESCRIPTION
# Assignee Section

## Description
Add cmake files to gitignore

### Steps for Testing

1. checkout branch
2. create a new branch based off this branch. Run cmake as per the wiki's instructions https://github.com/space-concordia-robotics/robotics-prototype/wiki/Building-the-C---code. 
3.Verify there's no unstaged cmake related files

closes #426 

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [x] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
