### PR TITLE
Pds1 disconnect 429

### DIFF
--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -199,7 +199,7 @@ function initRosWeb () {
   battery_voltage_listener = new ROSLIB.Topic({
     ros: ros,
     name: 'battery_voltage',
-    messageType: 'std_msgs/Float32'
+    messageType: 'mcu_control/Voltage'
   })
   battery_voltage_listener.subscribe(function (message) {
     // sets voltage to two decimal points
@@ -239,7 +239,7 @@ function initRosWeb () {
   battery_temps_listener = new ROSLIB.Topic({
     ros: ros,
     name: 'battery_temps',
-    messageType: 'geometry_msgs/Point'
+    messageType: 'mcu_control/ThermistorTemps'
   })
   battery_temps_listener.subscribe(function (message) {
     // sets temperatures to two decimal points
@@ -290,7 +290,7 @@ function initRosWeb () {
   wheel_motor_currents_listener = new ROSLIB.Topic({
     ros: ros,
     name: 'wheel_motor_currents',
-    messageType: 'sensor_msgs/JointState'
+    messageType: 'mcu_control/Currents'
   })
   wheel_motor_currents_listener.subscribe(function (message) {
     $('#right-front-current').text(parseFloat(message.effort[0]).toFixed(3))

--- a/robot/rospackages/src/mcu_control/scripts/PdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/PdsNode.py
@@ -170,7 +170,7 @@ if __name__ == '__main__':
     rospy.loginfo('Waiting for "' + service_name + '" service request from client')
     serv = rospy.Service(service_name, ArmRequest, handle_client)
 
-    search_success = init_serial(19200, mcuName)
+    search_success = init_serial(9600, mcuName)
 
     if not search_success:
         sys.exit(1)

--- a/robot/rospackages/src/mcu_control/scripts/SerialUtil.py
+++ b/robot/rospackages/src/mcu_control/scripts/SerialUtil.py
@@ -48,9 +48,8 @@ def attempt_uart(mcuName):
             dat=''
             data=None
             try:
-                dat = ser.readline().decode()
-                if type == arm:
-                    data = stripFeedback(dat) #not present in pdsnode
+                data = ser.readline().decode()
+                print('data', data)
             except:
                 rospy.logwarn('trouble reading from serial port')
             if data is not None:


### PR DESCRIPTION
# Assignee Section

## Description
Minimal changes in order to get the PDS ros node working properly on startup, as well the corrections to the GUI so that it properly displays those PDS related values again.

### Steps for Testing

Since this can really only be tested with the rover:
1. Start the rover
2. Start the GUI
3. All pages should show the battery voltage (slightly fluctuating), `N/A` for all the battery temp values, and on the rover page it should additionally fill the wheel motor table with electric current data.

closes #429

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process

- [x] Local Test Performed Successfully
- [x] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
