### PR TITLE
[#433] Fix battery_temp ThermistorTemps values displayed on the GUI

### DIFF
--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -1,312 +1,334 @@
-REQUEST_TIMEOUT = 3000
-ROTATE_TIMEOUT = 1000
-lastRotate = 0
+REQUEST_TIMEOUT = 3000;
+ROTATE_TIMEOUT = 1000;
+lastRotate = 0;
 
 // minimum and maximum acceptable battery voltages (volts)
-MIN_VOLTAGE = 12.5
-MAX_VOLTAGE = 16.8
-VOLTAGE_LEEWAY = 0.5
-VOLTAGE_WARNING = 1
+MIN_VOLTAGE = 12.5;
+MAX_VOLTAGE = 16.8;
+VOLTAGE_LEEWAY = 0.5;
+VOLTAGE_WARNING = 1;
 // minimum and maximum acceptable battery tempratures (degrees celcius)
-MIN_TEMP = 0
-MAX_TEMP = 85
-TEMP_LEEWAY = 1
-TEMP_WARNING = 10
+MIN_TEMP = 0;
+MAX_TEMP = 85;
+TEMP_LEEWAY = 1;
+TEMP_WARNING = 10;
 // variable to toggle unacceptable voltage and temperature indicators
-ALERT_ENABLE = true
+ALERT_ENABLE = true;
 
 // ROS logging severity level constants
-const ROSDEBUG = 1 // debug level
-const ROSINFO = 2  // general level
-const ROSWARN = 4  // warning level
-const ROSERROR = 8 // error level
-const ROSFATAL = 16 // fatal/critical level
-
+const ROSDEBUG = 1; // debug level
+const ROSINFO = 2; // general level
+const ROSWARN = 4; // warning level
+const ROSERROR = 8; // error level
+const ROSFATAL = 16; // fatal/critical level
 
 // logs below this level will not be published or printed. Issue #202 will allow the user to set this value
-const MINIMUM_LOG_LEVEL = ROSINFO
+const MINIMUM_LOG_LEVEL = ROSINFO;
 
-function initRosWeb () {
+function initRosWeb() {
   ros = new ROSLIB.Ros({
-    url: 'ws://' + env.HOST_IP + ':9090'
-  })
-  ros.on('connection', function () {
-    appendToConsole('Connected to websocket server.')
-    checkTaskStatuses()
-  })
-  ros.on('error', function (error) {
-    appendToConsole('Error connecting to websocket server: ', error)
-  })
-  ros.on('close', function () {
-    appendToConsole('Connection to websocket server closed.')
-  })
+    url: "ws://" + env.HOST_IP + ":9090",
+  });
+  ros.on("connection", function () {
+    appendToConsole("Connected to websocket server.");
+    checkTaskStatuses();
+  });
+  ros.on("error", function (error) {
+    appendToConsole("Error connecting to websocket server: ", error);
+  });
+  ros.on("close", function () {
+    appendToConsole("Connection to websocket server closed.");
+  });
 
   /* Logging */
 
   // publishes log messages to /rosout
   ros_logger = new ROSLIB.Topic({
     ros: ros,
-    name: 'rosout',
-    messageType: 'rosgraph_msgs/Log'
-  })
+    name: "rosout",
+    messageType: "rosgraph_msgs/Log",
+  });
 
   /* general controls */
 
   // setup a client for the ping service
   ping_client = new ROSLIB.Service({
     ros: ros,
-    name: 'ping_response',
-    serviceType: 'PingResponse'
-  })
+    name: "ping_response",
+    serviceType: "PingResponse",
+  });
 
   // setup a client for the mux_select service
   mux_select_client = new ROSLIB.Service({
     ros: ros,
-    name: 'mux_select',
-    serviceType: 'SelectMux'
-  })
+    name: "mux_select",
+    serviceType: "SelectMux",
+  });
   // setup a client for the serial_cmd service
-  serial_cmd_client = new ROSLIB.Service({ ros: ros, name: 'serial_cmd',
-    serviceType: 'SerialCmd'
-  })
+  serial_cmd_client = new ROSLIB.Service({
+    ros: ros,
+    name: "serial_cmd",
+    serviceType: "SerialCmd",
+  });
   // setup a client for the task_handler service
   task_handler_client = new ROSLIB.Service({
     ros: ros,
-    name: 'task_handler',
-    serviceType: 'HandleTask'
-  })
+    name: "task_handler",
+    serviceType: "HandleTask",
+  });
 
   /* arm controls */
 
   // setup a client for the arm_request service
   arm_request_client = new ROSLIB.Service({
     ros: ros,
-    name: 'arm_request',
-    serviceType: 'ArmRequest'
-  })
+    name: "arm_request",
+    serviceType: "ArmRequest",
+  });
   // setup a publisher for the arm_command topic
   arm_command_publisher = new ROSLIB.Topic({
     ros: ros,
-    name: 'arm_command',
-    messageType: 'std_msgs/String'
-  })
+    name: "arm_command",
+    messageType: "std_msgs/String",
+  });
   // setup a publisher for the ik_command topic
   ik_command_publisher = new ROSLIB.Topic({
     ros: ros,
-    name: 'ik_command',
-    messageType: 'IkCommand'
-  })
+    name: "ik_command",
+    messageType: "IkCommand",
+  });
 
   gripper_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'gripper_position',
-    messageType: 'geometry_msgs/Point'
-  })
+    name: "gripper_position",
+    messageType: "geometry_msgs/Point",
+  });
 
   gripper_listener.subscribe(function (msg) {
-    console.log('gripper_postion:', msg)
-  })
+    console.log("gripper_postion:", msg);
+  });
 
   // setup a subscriber for the arm_joint_states topic
   arm_joint_states_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'arm_joint_states',
-    messageType: 'sensor_msgs/JointState'
-  })
+    name: "arm_joint_states",
+    messageType: "sensor_msgs/JointState",
+  });
   arm_joint_states_listener.subscribe(function (message) {
     for (var angle in message.position) {
       // let motor = angle+1;
-      let motor = String.fromCharCode(angle.charCodeAt(0) + 1)
-      $('#m' + motor + '-angle').text(message.position[angle])
+      let motor = String.fromCharCode(angle.charCodeAt(0) + 1);
+      $("#m" + motor + "-angle").text(message.position[angle]);
     }
-  })
+  });
   // setup a subscriber for the arm_feedback topic
   arm_feedback_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'arm_feedback',
-    messageType: 'std_msgs/String'
-  })
+    name: "arm_feedback",
+    messageType: "std_msgs/String",
+  });
   arm_feedback_listener.subscribe(function (message) {
-    appendToConsole(message.data)
-  })
+    appendToConsole(message.data);
+  });
 
   /* rover commands */
 
   // setup a client for the rover_request service
   rover_request_client = new ROSLIB.Service({
     ros: ros,
-    name: 'rover_request',
-    serviceType: 'ArmRequest' // for now... might change
-  })
+    name: "rover_request",
+    serviceType: "ArmRequest", // for now... might change
+  });
 
   // setup a publisher for the rover_command topic
   rover_command_publisher = new ROSLIB.Topic({
     ros: ros,
-    name: 'rover_command',
-    messageType: 'std_msgs/String'
-  })
+    name: "rover_command",
+    messageType: "std_msgs/String",
+  });
 
   // setup a publisher for the pds_command topic
   pds_command_publisher = new ROSLIB.Topic({
     ros: ros,
-    name: 'pds_command',
-    messageType: 'std_msgs/String'
-  })
+    name: "pds_command",
+    messageType: "std_msgs/String",
+  });
 
   // setup a publisher for the science_command topic
   science_command_publisher = new ROSLIB.Topic({
     ros: ros,
-    name: 'science_command',
-    messageType: 'std_msgs/String'
-  })
+    name: "science_command",
+    messageType: "std_msgs/String",
+  });
 
   // setup a subscriber for the rover_joint_states topic
   rover_joint_states_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'rover_joint_states',
-    messageType: 'sensor_msgs/JointState'
-  })
+    name: "rover_joint_states",
+    messageType: "sensor_msgs/JointState",
+  });
   rover_joint_states_listener.subscribe(function (message) {
-    $('#right-front-rpm').text(message.velocity[0])
-    $('#right-mid-rpm').text(message.velocity[1])
-    $('#right-rear-rpm').text(message.velocity[2])
-    $('#left-front-rpm').text(message.velocity[3])
-    $('#left-mid-rpm').text(message.velocity[4])
-    $('#left-rear-rpm').text(message.velocity[5])
-  })
+    $("#right-front-rpm").text(message.velocity[0]);
+    $("#right-mid-rpm").text(message.velocity[1]);
+    $("#right-rear-rpm").text(message.velocity[2]);
+    $("#left-front-rpm").text(message.velocity[3]);
+    $("#left-mid-rpm").text(message.velocity[4]);
+    $("#left-rear-rpm").text(message.velocity[5]);
+  });
 
   // setup a subscriber for the rover_twist topic
   rover_twist_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'rover_twist',
-    messageType: 'geometry_msgs/Twist'
-  })
+    name: "rover_twist",
+    messageType: "geometry_msgs/Twist",
+  });
   rover_twist_listener.subscribe(function (message) {
-    $('#rover-speed').text(message.linear.x)
-    $('#rover-angular-velocity').text(message.angular.x)
-  })
+    $("#rover-speed").text(message.linear.x);
+    $("#rover-angular-velocity").text(message.angular.x);
+  });
   // setup a subscriber for the rover_feedback topic
   rover_feedback_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'rover_feedback',
-    messageType: 'std_msgs/String'
-  })
+    name: "rover_feedback",
+    messageType: "std_msgs/String",
+  });
   rover_feedback_listener.subscribe(function (message) {
-    appendToConsole(message.data, true, false)
-  })
+    appendToConsole(message.data, true, false);
+  });
 
   // setup a subscriber for the battery_voltage topic
   battery_voltage_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'battery_voltage',
-    messageType: 'mcu_control/Voltage'
-  })
+    name: "battery_voltage",
+    messageType: "mcu_control/Voltage",
+  });
   battery_voltage_listener.subscribe(function (message) {
     // sets voltage to two decimal points
-    let voltage = message.data.toFixed(2)
-    $('#battery-voltage').text(voltage)
+    let voltage = message.data.toFixed(2);
+    $("#battery-voltage").text(voltage);
 
     // if statement to control voltage indicator switching between acceptable(white) and unacceptable(red)
-    if ((voltage > MAX_VOLTAGE || voltage < MIN_VOLTAGE)) {
-      textColor('#battery-voltage', 'red')
+    if (voltage > MAX_VOLTAGE || voltage < MIN_VOLTAGE) {
+      textColor("#battery-voltage", "red");
 
-      if ($('#battery-voltage').attr('acceptable') === '1' && ALERT_ENABLE) {
-        $('#battery-voltage').attr('acceptable', '0')
-        errorSound()
+      if ($("#battery-voltage").attr("acceptable") === "1" && ALERT_ENABLE) {
+        $("#battery-voltage").attr("acceptable", "0");
+        errorSound();
         if (voltage > MAX_VOLTAGE) {
-          navModalMessage('Warning: Voltage too high', 'Disconnect Battery first and then the BMS, and then discharge the Battery to 16.8V')
-        } else if (voltage < MIN_VOLTAGE){
-          navModalMessage('Warning: Voltage too low', 'Turn rover off, disconnect Battery and BMS, and then charge battery to 16.8V')
+          navModalMessage(
+            "Warning: Voltage too high",
+            "Disconnect Battery first and then the BMS, and then discharge the Battery to 16.8V"
+          );
+        } else if (voltage < MIN_VOLTAGE) {
+          navModalMessage(
+            "Warning: Voltage too low",
+            "Turn rover off, disconnect Battery and BMS, and then charge battery to 16.8V"
+          );
         }
       }
-    } else if (voltage > MAX_VOLTAGE - VOLTAGE_LEEWAY || voltage < MIN_VOLTAGE + VOLTAGE_LEEWAY){
-      if ($('#battery-voltage').attr('acceptable') === '0') {
-        textColor('#battery-voltage', 'red')
+    } else if (
+      voltage > MAX_VOLTAGE - VOLTAGE_LEEWAY ||
+      voltage < MIN_VOLTAGE + VOLTAGE_LEEWAY
+    ) {
+      if ($("#battery-voltage").attr("acceptable") === "0") {
+        textColor("#battery-voltage", "red");
       }
-
     } else {
       if (voltage < MIN_VOLTAGE + VOLTAGE_WARNING) {
-        textColor('#battery-voltage', 'orange')
-
+        textColor("#battery-voltage", "orange");
       } else {
-        textColor('#battery-voltage', 'white')
+        textColor("#battery-voltage", "white");
       }
 
-      if ($('#battery-voltage').attr('acceptable') === '0') $('#battery-voltage').attr('acceptable', '1')
+      if ($("#battery-voltage").attr("acceptable") === "0")
+        $("#battery-voltage").attr("acceptable", "1");
     }
-  })
+  });
   // setup a subscriber for the battery_temps topic
   battery_temps_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'battery_temps',
-    messageType: 'mcu_control/ThermistorTemps'
-  })
+    name: "battery_temps",
+    messageType: "mcu_control/ThermistorTemps",
+  });
   battery_temps_listener.subscribe(function (message) {
     // sets temperatures to two decimal points
     let temps = [
-      parseFloat(message.x).toFixed(2),
-      parseFloat(message.y).toFixed(2),
-      parseFloat(message.z).toFixed(2)
-    ]
+      parseFloat(message.therm1).toFixed(2),
+      parseFloat(message.therm2).toFixed(2),
+      parseFloat(message.therm3).toFixed(2),
+    ];
 
-    $('.battery-temp').each(function(i, obj) {
-      let $obj = $(obj)
-      let temperature = temps[i]
-      $obj.text(temperature)
+    $(".battery-temp").each(function (i, obj) {
+      let $obj = $(obj);
+      let temperature = temps[i];
+      $obj.text(temperature);
 
-      if ((temperature > MAX_TEMP || temperature < MIN_TEMP)) {
-        $obj.css({'color': 'red'})
+      if (temperature > MAX_TEMP || temperature < MIN_TEMP) {
+        $obj.css({ color: "red" });
 
-        if ($obj.attr('acceptable') === '1' && ALERT_ENABLE) {
-          $obj.attr('acceptable', '0')
-          errorSound()
+        if ($obj.attr("acceptable") === "1" && ALERT_ENABLE) {
+          $obj.attr("acceptable", "0");
+          errorSound();
           if (temperature > MAX_TEMP) {
-            navModalMessage('Warning: Battery temperature (' + $obj.attr('sensorName') + ') too high.', 'Decrease temperature')
+            navModalMessage(
+              "Warning: Battery temperature (" +
+                $obj.attr("sensorName") +
+                ") too high.",
+              "Decrease temperature"
+            );
           } else if (temperature < MIN_TEMP) {
-            navModalMessage('Warning: Battery temperature (' + $obj.attr('sensorName') + ') too low.', 'Increase temperature')
+            navModalMessage(
+              "Warning: Battery temperature (" +
+                $obj.attr("sensorName") +
+                ") too low.",
+              "Increase temperature"
+            );
           }
         }
-      } else if (temperature > MAX_TEMP - TEMP_LEEWAY || temperature < MIN_TEMP + TEMP_LEEWAY){
-        if ($obj.attr('acceptable') === '0') {
-          $obj.css({'color': 'red'})
+      } else if (
+        temperature > MAX_TEMP - TEMP_LEEWAY ||
+        temperature < MIN_TEMP + TEMP_LEEWAY
+      ) {
+        if ($obj.attr("acceptable") === "0") {
+          $obj.css({ color: "red" });
         } else {
-          $obj.css({'color': 'orange'})
+          $obj.css({ color: "orange" });
         }
-
       } else {
-        if (temperature > MAX_TEMP - TEMP_WARNING || temperature < MIN_TEMP + TEMP_WARNING) {
-          $obj.css({'color': 'orange'})
-
+        if (
+          temperature > MAX_TEMP - TEMP_WARNING ||
+          temperature < MIN_TEMP + TEMP_WARNING
+        ) {
+          $obj.css({ color: "orange" });
         } else {
-          $obj.css({'color': 'white'})
+          $obj.css({ color: "white" });
         }
 
-        if ($obj.attr('acceptable') === '0') $obj.attr('acceptable', '1')
+        if ($obj.attr("acceptable") === "0") $obj.attr("acceptable", "1");
       }
     });
-
-  })
+  });
   // setup a subscriber for the wheel_motor_currents topic
   wheel_motor_currents_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'wheel_motor_currents',
-    messageType: 'mcu_control/Currents'
-  })
+    name: "wheel_motor_currents",
+    messageType: "mcu_control/Currents",
+  });
   wheel_motor_currents_listener.subscribe(function (message) {
-    $('#right-front-current').text(parseFloat(message.effort[0]).toFixed(3))
-    $('#right-mid-current').text(parseFloat(message.effort[1]).toFixed(3))
-    $('#right-rear-current').text(parseFloat(message.effort[2]).toFixed(3))
-    $('#left-front-current').text(parseFloat(message.effort[3]).toFixed(3))
-    $('#left-mid-current').text(parseFloat(message.effort[4]).toFixed(3))
-    $('#left-rear-current').text(parseFloat(message.effort[5]).toFixed(3))
-  })
+    $("#right-front-current").text(parseFloat(message.effort[0]).toFixed(3));
+    $("#right-mid-current").text(parseFloat(message.effort[1]).toFixed(3));
+    $("#right-rear-current").text(parseFloat(message.effort[2]).toFixed(3));
+    $("#left-front-current").text(parseFloat(message.effort[3]).toFixed(3));
+    $("#left-mid-current").text(parseFloat(message.effort[4]).toFixed(3));
+    $("#left-rear-current").text(parseFloat(message.effort[5]).toFixed(3));
+  });
 
   // setup a subcriber function for rover_position topic
   rover_position_listener = new ROSLIB.Topic({
     ros: ros,
-    name: 'rover_position',
-    messageType: 'geometry_msgs/Point'
-  })
+    name: "rover_position",
+    messageType: "geometry_msgs/Point",
+  });
 }
 
 /* functions used in main code */
@@ -314,17 +336,17 @@ function initRosWeb () {
 /**
  * Gets the current time and formats it for ROS and the GUI.
  * @return array of two variables: ROS time object, string containing hh:mm:ss
-*/
-function rosTimestamp () {
+ */
+function rosTimestamp() {
   // next few lines taken and adjusted from roslibjs action server example
-  let currentTime = new Date()
-  let secs = currentTime.getTime()/1000 // seconds before truncating the decimal
-  let secsFloored = Math.floor(secs) // seconds after truncating
-  let nanoSecs = Math.round(1000000000*(secs-secsFloored)) // nanoseconds since the previous second
+  let currentTime = new Date();
+  let secs = currentTime.getTime() / 1000; // seconds before truncating the decimal
+  let secsFloored = Math.floor(secs); // seconds after truncating
+  let nanoSecs = Math.round(1000000000 * (secs - secsFloored)); // nanoseconds since the previous second
 
   // return a dictionary for the ROS log and a string for the gui console
-  let stampTime = currentTime.toString().split(' ')[4] // hh:mm:ss from date object
-  return [{secs : secsFloored, nsecs : nanoSecs}, stampTime]
+  let stampTime = currentTime.toString().split(" ")[4]; // hh:mm:ss from date object
+  return [{ secs: secsFloored, nsecs: nanoSecs }, stampTime];
 }
 
 /**
@@ -332,25 +354,25 @@ function rosTimestamp () {
  * @param logLevel one of the ROS loglevel constants defined above
  * @param timestamp ros time object containing seconds and nanoseconds
  * @param message the log message
-*/
-function publishRosLog (logLevel, timestamp, message) {
+ */
+function publishRosLog(logLevel, timestamp, message) {
   ros_logger.publish(
     new ROSLIB.Message({
       // I'm only publishing the essentials. We could include more info if so desired
-      header : {
+      header: {
         // seq // uint32: sequence ID, seems to increment automatically
-        stamp : timestamp // dictionary: contains truncated seconds and nanoseconds
+        stamp: timestamp, // dictionary: contains truncated seconds and nanoseconds
         // frame_id // string: probably only useful for tf
       },
-      level : logLevel, // int: see log level constants above
+      level: logLevel, // int: see log level constants above
       // name : '/web_gui', // name of the node (proposed)
-      msg : message, // string: this is the log message
+      msg: message, // string: this is the log message
       // file // string: we could specify the js file that generated the log
       // function // string: we could specify the parent function that generated the log
       // line // uint32: we could specify the specific line of code that generated the log
       // topics // string[]: topic names that the node publishes
     })
-  )
+  );
 }
 
 /**
@@ -358,33 +380,33 @@ function publishRosLog (logLevel, timestamp, message) {
  * Also calls publishRosLog with the message and parameters.
  * @param logLevel one of the ROS loglevel constants defined above
  * @param message the log message
-*/
-function rosLog (logLevel, message, devConsole = true, guiConsole = true) {
-  logData = {}
-  logData[ROSDEBUG] = {prefix : '[DEBUG]', type : 'log'}
-  logData[ROSINFO] = {prefix : '[INFO]', type : 'log'}
-  logData[ROSWARN] = {prefix : '[WARN]', type : 'warn'}
-  logData[ROSERROR] = {prefix : '[ERROR]', type : 'error'}
-  logData[ROSFATAL] = {prefix : '[FATAL]', type : 'error'}
+ */
+function rosLog(logLevel, message, devConsole = true, guiConsole = true) {
+  logData = {};
+  logData[ROSDEBUG] = { prefix: "[DEBUG]", type: "log" };
+  logData[ROSINFO] = { prefix: "[INFO]", type: "log" };
+  logData[ROSWARN] = { prefix: "[WARN]", type: "warn" };
+  logData[ROSERROR] = { prefix: "[ERROR]", type: "error" };
+  logData[ROSFATAL] = { prefix: "[FATAL]", type: "error" };
 
-  stamps = rosTimestamp()
-  consoleMsg = logData[logLevel].prefix + ' [' + stamps[1] + ']: ' + message
+  stamps = rosTimestamp();
+  consoleMsg = logData[logLevel].prefix + " [" + stamps[1] + "]: " + message;
 
   if (devConsole) {
-    if (logData[logLevel].type === 'log') {
-      console.log(consoleMsg)
-    } else if (logData[logLevel].type === 'warn') {
-      console.warn(consoleMsg)
-    } else if (logData[logLevel].type === 'error') {
-      console.error(consoleMsg)
+    if (logData[logLevel].type === "log") {
+      console.log(consoleMsg);
+    } else if (logData[logLevel].type === "warn") {
+      console.warn(consoleMsg);
+    } else if (logData[logLevel].type === "error") {
+      console.error(consoleMsg);
     }
   }
   if (guiConsole) {
     // false means don't append (again) to the dev console
-    appendToConsole(consoleMsg, false)
+    appendToConsole(consoleMsg, false);
   }
   // log messages go to log file: currently rosout.log
-  publishRosLog(logLevel, stamps[0], message)
+  publishRosLog(logLevel, stamps[0], message);
 }
 
 // these functions copy the rospy logging functions
@@ -392,111 +414,113 @@ function rosLog (logLevel, message, devConsole = true, guiConsole = true) {
  * Sends a debug message with timestamp to the GUI and chrome consoles.
  * Also publishes it to /rosout.
  * @param message the log message
-*/
-function logDebug (message, devConsole = true, guiConsole = true) {
+ */
+function logDebug(message, devConsole = true, guiConsole = true) {
   // unlike rospy, (currently) the debug messages we generate will get published
-  rosLog(ROSDEBUG, message, devConsole, guiConsole)
+  rosLog(ROSDEBUG, message, devConsole, guiConsole);
 }
 /**
  * Sends an info message with timestamp to the GUI and chrome consoles.
  * Also publishes it to /rosout.
  * @param message the log message
-*/
-function logInfo (message, devConsole = true, guiConsole = true) {
-  rosLog(ROSINFO, message, devConsole, guiConsole)
+ */
+function logInfo(message, devConsole = true, guiConsole = true) {
+  rosLog(ROSINFO, message, devConsole, guiConsole);
 }
 /**
  * Sends a warning message with timestamp to the GUI and chrome consoles.
  * Also publishes it to /rosout.
  * @param message the log message
-*/
-function logWarn (message, devConsole = true, guiConsole = true) {
-  rosLog(ROSWARN, message, devConsole, guiConsole)
+ */
+function logWarn(message, devConsole = true, guiConsole = true) {
+  rosLog(ROSWARN, message, devConsole, guiConsole);
 }
 /**
  * Sends an error message with timestamp to the GUI and chrome consoles.
  * Also publishes it to /rosout.
  * @param message the log message
-*/
-function logErr (message, devConsole = true, guiConsole = true) {
-  rosLog(ROSERROR, message, devConsole, guiConsole)
+ */
+function logErr(message, devConsole = true, guiConsole = true) {
+  rosLog(ROSERROR, message, devConsole, guiConsole);
 }
 /**
  * Sends a fatal error message with timestamp to the GUI and chrome consoles.
  * Also publishes it to /rosout.
  * @param message the log message
-*/
-function logFatal (message, devConsole = true, guiConsole = true) {
-  rosLog(ROSFATAL, message, devConsole, guiConsole)
+ */
+function logFatal(message, devConsole = true, guiConsole = true) {
+  rosLog(ROSFATAL, message, devConsole, guiConsole);
 }
 
-function requestMuxChannel (elemID, callback, timeout = REQUEST_TIMEOUT) {
-  let dev = elemID[elemID.length - 1]
-  let request = new ROSLIB.ServiceRequest({ device: dev })
-  let sentTime = new Date().getTime()
+function requestMuxChannel(elemID, callback, timeout = REQUEST_TIMEOUT) {
+  let dev = elemID[elemID.length - 1];
+  let request = new ROSLIB.ServiceRequest({ device: dev });
+  let sentTime = new Date().getTime();
 
-  if (dev != '?') {
+  if (dev != "?") {
     appendToConsole(
-      'Sending request to switch to channel ' + $('a' + elemID).text()
-    )
+      "Sending request to switch to channel " + $("a" + elemID).text()
+    );
   }
 
   let timer = setTimeout(function () {
-    callback([false, elemID + ' timeout after ' + timeout / 1000 + ' seconds'])
-  }, timeout)
+    callback([false, elemID + " timeout after " + timeout / 1000 + " seconds"]);
+  }, timeout);
 
   mux_select_client.callService(request, function (result) {
-    clearTimeout(timer)
-    let latency = millisSince(sentTime)
-    let msg = result.response // .slice(0, result.response.length - 1) // remove newline character
-    if (msg.includes('failed') || msg.includes('ERROR')) {
+    clearTimeout(timer);
+    let latency = millisSince(sentTime);
+    let msg = result.response; // .slice(0, result.response.length - 1) // remove newline character
+    if (msg.includes("failed") || msg.includes("ERROR")) {
       // how to account for a lack of response?
-      appendToConsole('Request failed. Received "' + msg + '"')
-      callback([false, msg])
-    } else if (msg.includes('Current:')) {
+      appendToConsole('Request failed. Received "' + msg + '"');
+      callback([false, msg]);
+    } else if (msg.includes("Current:")) {
       // -2 since last character is newline, second last is actual channel
-      $('button#mux').text('Device ' + $('a#mux-' + msg[msg.length - 2]).text())
+      $("button#mux").text(
+        "Device " + $("a#mux-" + msg[msg.length - 2]).text()
+      );
     } else {
-      $('button#mux').text('Device ' + $('a' + elemID).text())
+      $("button#mux").text("Device " + $("a" + elemID).text());
       appendToConsole(
-        'Received "' + msg + '" with ' + latency.toString() + ' ms latency'
-      )
-      callback([true])
+        'Received "' + msg + '" with ' + latency.toString() + " ms latency"
+      );
+      callback([true]);
     }
-  })
+  });
 }
-function requestSerialCommand (command, callback) {
-  let request = new ROSLIB.ServiceRequest({ msg: command + '\n' })
-  let sentTime = new Date().getTime()
+function requestSerialCommand(command, callback) {
+  let request = new ROSLIB.ServiceRequest({ msg: command + "\n" });
+  let sentTime = new Date().getTime();
 
-  logInfo('Sending request to execute command "' + command + '"')
+  logInfo('Sending request to execute command "' + command + '"');
 
   mux_select_client.callService(request, function (result) {
-    let latency = millisSince(sentTime)
-    console.log(result)
-    let msg = result.response // .slice(0, result.response.length - 1) // remove newline character
-    if (msg.includes('failed') || msg.includes('ERROR')) {
+    let latency = millisSince(sentTime);
+    console.log(result);
+    let msg = result.response; // .slice(0, result.response.length - 1) // remove newline character
+    if (msg.includes("failed") || msg.includes("ERROR")) {
       // how to account for a lack of response?
-      appendToConsole('Request failed. Received "' + msg + '"')
-      callback([false, msg])
+      appendToConsole('Request failed. Received "' + msg + '"');
+      callback([false, msg]);
     } else {
       appendToConsole(
-        'Received "' + msg + '" with ' + latency.toString() + ' ms latency'
-      )
-      callback([true])
+        'Received "' + msg + '" with ' + latency.toString() + " ms latency"
+      );
+      callback([true]);
     }
-  })
+  });
 }
 
-STATUS_STOP=0
-STATUS_START=1
-STATUS_CHECK=2
-ARM_LISTENER_TASK = 'arm_listener'
-ROVER_LISTENER_TASK = 'rover_listener'
-SCIENCE_LISTENER_TASK = 'science_listener'
-PDS_LISTENER_TASK = 'pds_listener'
-CAMERA_TASK = 'camera_stream'
-CAMERA_PORTS = 'camera_ports'
+STATUS_STOP = 0;
+STATUS_START = 1;
+STATUS_CHECK = 2;
+ARM_LISTENER_TASK = "arm_listener";
+ROVER_LISTENER_TASK = "rover_listener";
+SCIENCE_LISTENER_TASK = "science_listener";
+PDS_LISTENER_TASK = "pds_listener";
+CAMERA_TASK = "camera_stream";
+CAMERA_PORTS = "camera_ports";
 
 /**
  * Sends a request to the task handler.
@@ -511,190 +535,199 @@ CAMERA_PORTS = 'camera_ports'
  * @reqArgs Arguments of the request
  * @timeout Timeout of the request
  */
-function requestTask (
+function requestTask(
   reqTask,
   reqStatus,
-  callback = arg => {},
-  reqArgs = '',
+  callback = (arg) => {},
+  reqArgs = "",
   timeout = REQUEST_TIMEOUT
 ) {
-
-  let request = new ROSLIB.ServiceRequest({ task: reqTask, status: reqStatus, args: reqArgs })
-  let sentTime = new Date().getTime()
+  let request = new ROSLIB.ServiceRequest({
+    task: reqTask,
+    status: reqStatus,
+    args: reqArgs,
+  });
+  let sentTime = new Date().getTime();
 
   if (reqStatus == STATUS_STOP) {
-    logInfo('Sending request to stop ' + reqTask + ' task')
+    logInfo("Sending request to stop " + reqTask + " task");
   } else if (reqStatus == STATUS_START) {
-    logInfo('Sending request to start ' + reqTask + ' task')
+    logInfo("Sending request to start " + reqTask + " task");
   } else if (reqStatus == STATUS_CHECK) {
-    logInfo('Sending request to check ' + reqTask + ' task status')
+    logInfo("Sending request to check " + reqTask + " task status");
   }
 
   let timer = setTimeout(function () {
-    callback([false, reqTask + ' timeout after ' + timeout / 1000 + ' seconds'])
-  }, timeout)
+    callback([
+      false,
+      reqTask + " timeout after " + timeout / 1000 + " seconds",
+    ]);
+  }, timeout);
 
   task_handler_client.callService(request, function (result) {
-    clearTimeout(timer)
-    let latency = millisSince(sentTime)
-    let msg = result.response
+    clearTimeout(timer);
+    let latency = millisSince(sentTime);
+    let msg = result.response;
     if (
-      msg.includes('Failed') ||
-      msg.includes('shutdown request') ||
-      msg.includes('unavailable') ||
-      msg.includes('is already running') ||
-      msg.includes('not available')
+      msg.includes("Failed") ||
+      msg.includes("shutdown request") ||
+      msg.includes("unavailable") ||
+      msg.includes("is already running") ||
+      msg.includes("not available")
     ) {
-      appendToConsole('Request failed. Received "' + msg + '"')
-      callback([false, msg])
+      appendToConsole('Request failed. Received "' + msg + '"');
+      callback([false, msg]);
     } else {
       appendToConsole(
-        'Received "' + msg + '" with ' + latency.toString() + ' ms latency'
-      )
+        'Received "' + msg + '" with ' + latency.toString() + " ms latency"
+      );
 
-      callback([true, msg])
+      callback([true, msg]);
     }
-  })
+  });
 }
 
-function checkTaskStatuses () {
-  if ($('#camera-local-mode-btn').length >= 1) {
-    let isLocal = getCookie('localCameras')
+function checkTaskStatuses() {
+  if ($("#camera-local-mode-btn").length >= 1) {
+    let isLocal = getCookie("localCameras");
 
-    if (isLocal == '1') {
-      $('#camera-local-mode-btn')[0].checked = true
+    if (isLocal == "1") {
+      $("#camera-local-mode-btn")[0].checked = true;
     } else {
-      $('#camera-local-mode-btn')[0].checked = false
+      $("#camera-local-mode-btn")[0].checked = false;
     }
   }
   // regardless of page we're on
-  requestMuxChannel('?', function (currentChannel) {
-    console.log('currentChannel', currentChannel)
-  })
-  if (window.location.pathname == '/') {
+  requestMuxChannel("?", function (currentChannel) {
+    console.log("currentChannel", currentChannel);
+  });
+  if (window.location.pathname == "/") {
     // check arm listener status
     requestTask(ARM_LISTENER_TASK, STATUS_CHECK, (msgs) => {
-      printErrToConsole(msgs)
+      printErrToConsole(msgs);
       if (msgs[0] && msgs.length == 2) {
-        if (msgs[1].includes('not running')) {
-          $('#toggle-arm-listener-btn')[0].checked = false
-        } else if (msgs[1].includes('running')) {
-          $('#toggle-arm-listener-btn')[0].checked = true
+        if (msgs[1].includes("not running")) {
+          $("#toggle-arm-listener-btn")[0].checked = false;
+        } else if (msgs[1].includes("running")) {
+          $("#toggle-arm-listener-btn")[0].checked = true;
         }
       }
-    })
-  } else if (window.location.pathname == '/science') {
+    });
+  } else if (window.location.pathname == "/science") {
     requestTask(SCIENCE_LISTENER_TASK, STATUS_CHECK, function (msgs) {
-      printErrToConsole(msgs)
+      printErrToConsole(msgs);
       if (msgs[0] && msgs.length == 2) {
-        if (msgs[1].includes('not running')) {
-          $('#science-listener-btn')[0].checked = false
-        } else if (msgs[1].includes('running')) {
-          $('#science-listener-btn')[0].checked = true
+        if (msgs[1].includes("not running")) {
+          $("#science-listener-btn")[0].checked = false;
+        } else if (msgs[1].includes("running")) {
+          $("#science-listener-btn")[0].checked = true;
         }
       }
-    })
-  } else if (window.location.pathname == '/pds') {
+    });
+  } else if (window.location.pathname == "/pds") {
     // check rover listener status
     requestTask(PDS_LISTENER_TASK, STATUS_CHECK, function (msgs) {
-      printErrToConsole(msgs)
+      printErrToConsole(msgs);
       if (msgs[0] && msgs.length == 2) {
-        if (msgs[1].includes('not running')) {
-          $('#toggle-pds-listener-btn')[0].checked = false
-        } else if (msgs[1].includes('running')) {
-          $('#toggle-pds-listener-btn')[0].checked = true
+        if (msgs[1].includes("not running")) {
+          $("#toggle-pds-listener-btn")[0].checked = false;
+        } else if (msgs[1].includes("running")) {
+          $("#toggle-pds-listener-btn")[0].checked = true;
         }
       }
-    })
+    });
   }
 }
 
-function sendRequest (device, command, callback, timeout = REQUEST_TIMEOUT) {
-  let request = new ROSLIB.ServiceRequest({ msg: command })
-  let sentTime = new Date().getTime()
+function sendRequest(device, command, callback, timeout = REQUEST_TIMEOUT) {
+  let request = new ROSLIB.ServiceRequest({ msg: command });
+  let sentTime = new Date().getTime();
 
-  logInfo('Sending request to execute command "' + command + '"')
+  logInfo('Sending request to execute command "' + command + '"');
 
   let timer = setTimeout(function () {
-    callback([false, command + ' timeout after ' + timeout / 1000 + ' seconds'])
-  }, timeout)
+    callback([
+      false,
+      command + " timeout after " + timeout / 1000 + " seconds",
+    ]);
+  }, timeout);
 
-  var requestClient
+  var requestClient;
   switch (device) {
-    case 'Arm':
-      requestClient = arm_request_client
-      break
-    case 'Rover':
-      requestClient = rover_request_client
-      break
-    case 'Science':
-      requestClient = science_request_client
-      break
-    case 'PDS':
-      requestClient = pds_request_client
-      break
+    case "Arm":
+      requestClient = arm_request_client;
+      break;
+    case "Rover":
+      requestClient = rover_request_client;
+      break;
+    case "Science":
+      requestClient = science_request_client;
+      break;
+    case "PDS":
+      requestClient = pds_request_client;
+      break;
   }
 
   requestClient.callService(request, function (result) {
-    clearTimeout(timer)
-    let latency = millisSince(sentTime)
-    console.log(result)
-    let msg = result.response // .slice(0, result.response.length - 1) // remove newline character
+    clearTimeout(timer);
+    let latency = millisSince(sentTime);
+    console.log(result);
+    let msg = result.response; // .slice(0, result.response.length - 1) // remove newline character
     if (!result.success) {
       // how to account for a lack of response?
-      appendToConsole('Request failed. Received "' + msg + '"')
+      appendToConsole('Request failed. Received "' + msg + '"');
       // return false
-      callback([false, msg])
+      callback([false, msg]);
     } else {
       appendToConsole(
-        'Received "' + msg + '" with ' + latency.toString() + ' ms latency'
-      )
+        'Received "' + msg + '" with ' + latency.toString() + " ms latency"
+      );
       // return true
-      callback([true, msg])
+      callback([true, msg]);
     }
-  })
+  });
 }
 
 /*
 returns the IP portion of the currently set ROS_MASTER_URI
 */
-function getRoverIP (callback) {
-  logInfo('roverIP: ' + env.ROS_MASTER_IP)
-  logInfo('hostIP: ' + env.HOST_IP)
-  return env.ROS_MASTER_IP
+function getRoverIP(callback) {
+  logInfo("roverIP: " + env.ROS_MASTER_IP);
+  logInfo("hostIP: " + env.HOST_IP);
+  return env.ROS_MASTER_IP;
 }
 
 /*
 command sending
 */
-function sendIKCommand (cmd) {
-  let command = new ROSLIB.Message({ data: cmd })
-  logInfo('Sending "' + cmd + '" to IK node')
-  ik_command_publisher.publish(cmd)
+function sendIKCommand(cmd) {
+  let command = new ROSLIB.Message({ data: cmd });
+  logInfo('Sending "' + cmd + '" to IK node');
+  ik_command_publisher.publish(cmd);
 }
 
-function sendArmCommand (cmd) {
-  let command = new ROSLIB.Message({ data: cmd })
-  logInfo('Sending "' + cmd + '" to arm Teensy')
-  arm_command_publisher.publish(command)
+function sendArmCommand(cmd) {
+  let command = new ROSLIB.Message({ data: cmd });
+  logInfo('Sending "' + cmd + '" to arm Teensy');
+  arm_command_publisher.publish(command);
 }
 
-function sendRoverCommand (cmd) {
-  logDebug('Sending "' + cmd + '" to Rover Teensy')
-  let command = new ROSLIB.Message({ data: cmd })
-  logInfo('Sending "' + cmd + '" to rover Teensy')
-  rover_command_publisher.publish(command)
+function sendRoverCommand(cmd) {
+  logDebug('Sending "' + cmd + '" to Rover Teensy');
+  let command = new ROSLIB.Message({ data: cmd });
+  logInfo('Sending "' + cmd + '" to rover Teensy');
+  rover_command_publisher.publish(command);
 }
 
-function sendPdsCommand (cmd) {
-  logDebug('Sending "' + cmd + '" to PDS Teensy')
-  let command = new ROSLIB.Message({ data: cmd })
-  logInfo('Sending "' + cmd + '" to PDS')
-  pds_command_publisher.publish(command)
+function sendPdsCommand(cmd) {
+  logDebug('Sending "' + cmd + '" to PDS Teensy');
+  let command = new ROSLIB.Message({ data: cmd });
+  logInfo('Sending "' + cmd + '" to PDS');
+  pds_command_publisher.publish(command);
 }
 
-function sendScienceCommand (cmd) {
-  let command = new ROSLIB.Message({ data: cmd })
-  logInfo('Sending "' + cmd + '" to science Teensy')
-  science_command_publisher.publish(command)
+function sendScienceCommand(cmd) {
+  let command = new ROSLIB.Message({ data: cmd });
+  logInfo('Sending "' + cmd + '" to science Teensy');
+  science_command_publisher.publish(command);
 }

--- a/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
@@ -229,7 +229,7 @@ def publish_mock_data(voltages, temps, currents):
         prevParameterStates["PDS_mock_wheel_current5"] = rospy.get_param("PDS_mock_wheel_current5")
         prevParameterStates["PDS_mock_wheel_current6"] = rospy.get_param("PDS_mock_wheel_current6")
 
-        #Change previous values for voltage and thermistor temps
+        #Change previous values for evaluated parameters
         prevParameterValues["PDS_mock_voltage"] = currentVoltage
         prevParameterValues["PDS_mock_temp1"] = currentTemp1
         prevParameterValues["PDS_mock_temp2"] = currentTemp2

--- a/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
@@ -10,7 +10,10 @@ from mcu_control.msg import ThermistorTemps, Voltage, Currents
 from decimal import *
 
 
-#Log all data during publishing (Added in publish_mock_data to see values in CLI)
+#Log all data during publishing
+#Add to publish_mock_data to log published data in CLI
+#Remove from publish_mock_data if not needed
+#Used for testing purposes
 def rospyPublishedValueLogger(prevParameterStates, prevParameterValues):
     #Log new values when posted
     rospy.loginfo("PDS_mock_voltage : " + str(prevParameterValues.get("PDS_mock_voltage")))
@@ -112,7 +115,7 @@ def publish_mock_data(voltages, temps, currents):
     prevWheelCurrentStates.append(("PDS_mock_wheel_current5", prevWheelCurrent5State))
     prevWheelCurrentStates.append(("PDS_mock_wheel_current6", prevWheelCurrent6State))
 
-    #Create dict with all parameter states (easily append to for scalability)
+    #Create dict with all parameter states (append to for scalability)
     prevParameterStates = {
         "PDS_mock_voltage": prevVoltageState,
         "PDS_mock_temp1": prevTemp1State,
@@ -126,7 +129,7 @@ def publish_mock_data(voltages, temps, currents):
         "PDS_mock_wheel_current6": prevWheelCurrent6State
     }
 
-    #Create dict with all parameter values (easily append to for scalability)
+    #Create dict with all parameter values (append to for scalability)
     prevParameterValues = {
         "PDS_mock_voltage": None,
         "PDS_mock_temp1": None,

--- a/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
@@ -10,20 +10,6 @@ from mcu_control.msg import ThermistorTemps, Voltage
 from decimal import *
 
 
-class VoltageMonitor(object):
-
-    def __init__(self, pub, voltages):
-        self._pub = pub
-        self._voltages = voltages
-
-
-class TemperatureMonitor(object):
-
-    def __init__(self, pub, temps):
-        self._pub = pub
-        self._temps = temps
-
-
 #Get parameter state and assign value
 def get_parameter_state(parameterState, values, prevValue, noise, increment):
     try:
@@ -34,24 +20,25 @@ def get_parameter_state(parameterState, values, prevValue, noise, increment):
 
     currentGetValue = 0
     if (param == "high"):
-        currentGetValue = values[0][1]
+        currentGetValue = values.get("high")
     elif (param == "normal"):
-        currentGetValue = values[1][1]
+        currentGetValue = values.get("normal")
     elif (param == "low"):
-        currentGetValue = values[2][1]
+        currentGetValue = values.get("low")
     else:
         rospy.loginfo("Failed: Invalid parameter entered")
 
     #Increment to the desired value with noise included
-    remainder = prevValue - currentGetValue
+    remainder = currentGetValue - prevValue
     if ((abs(remainder) >= (noise + increment))):
         #If negative: increment, if positive: decrement
         if (remainder > 0):
-            currentGetValue -= (increment + (noise * (random.randint(-1, 1))))
+            prevValue = round(prevValue + (noise * (random.uniform(-1, 1))) + increment, 2)
         else:
-            currentGetValue += (increment + (noise * (random.randint(-1, 1))))
-
-    return currentGetValue
+            prevValue = round(prevValue + (noise * (random.uniform(-1, 1))) - increment, 2)
+    else:
+        prevValue = round(currentGetValue + (noise * (random.uniform(-1, 1))), 2)
+    return prevValue
 
 
 def publish_mock_data(voltages, temps):
@@ -71,11 +58,26 @@ def publish_mock_data(voltages, temps):
     prevTemp2State = rospy.get_param("PDS_mock_temp2")
     prevTemp3State = rospy.get_param("PDS_mock_temp3")
 
+    # #Initialize starting state on program startup
+    # prevVoltageState = "normal"
+    # prevTemp1State = "normal"
+    # prevTemp2State = "normal"
+    # prevTemp3State = "normal"
+
+    # #Set data to voltage and thermistortemp types
+    # voltage.data = float(currentVoltage)
+    # thermistorTemps.therm1 = float(currentTemp1)
+    # thermistorTemps.therm2 = float(currentTemp2)
+    # thermistorTemps.therm3 = float(currentTemp3)
+
+    # #Publish voltage and thermistortemps
+    # pubVoltage.publish(voltage)
+    # pubTemp.publish(thermistorTemps)
+
     #Initialize variables for previous voltage and temp
-    prevVoltageValue = None
     prevTempStates = []
 
-    #Create list of temps to loop through when assigning new temps
+    #Create list of temperatures to loop through when assigning new temperatures
     prevTempStates.append(("PDS_mock_temp1", prevTemp1State))
     prevTempStates.append(("PDS_mock_temp2", prevTemp2State))
     prevTempStates.append(("PDS_mock_temp3", prevTemp3State))
@@ -96,63 +98,66 @@ def publish_mock_data(voltages, temps):
         "PDS_mock_temp3": None
     }
 
-    #Acquire parameter settings WHILE ROS IS RUNNING
-    while not rospy.is_shutdown():
-        #-------------------------------------------------------------------
-        #Set voltage value for particular parameter
-        if (prevVoltageState == "high"):
-            prevParameterValues["PDS_mock_voltage"] = voltages[0][1]
-        elif (prevVoltageState == "normal"):
-            prevParameterValues["PDS_mock_voltage"] = voltages[1][1]
-        elif (prevVoltageState == "low"):
-            prevParameterValues["PDS_mock_voltage"] = voltages[2][1]
+    #Set initial current voltage
+    if (prevVoltageState == "high"):
+        prevParameterValues["PDS_mock_voltage"] = voltages.get("high")
+    elif (prevVoltageState == "normal"):
+        prevParameterValues["PDS_mock_voltage"] = voltages.get("normal")
+    elif (prevVoltageState == "low"):
+        prevParameterValues["PDS_mock_voltage"] = voltages.get("low")
+    else:
+        rospy.loginfo("Failed: Invalid parameter entered")
+    currentVoltage = prevParameterValues.get("PDS_mock_voltage")
+
+    #Set initial 3 current temperatures
+    for x in range(len(prevTempStates)):
+        if (prevTempStates[x][1] == "high"):
+            prevParameterValues[prevTempStates[x][0]] = temps.get("high")
+        elif (prevTempStates[x][1] == "normal"):
+            prevParameterValues[prevTempStates[x][0]] = temps.get("normal")
+        elif (prevTempStates[x][1] == "low"):
+            prevParameterValues[prevTempStates[x][0]] = temps.get("low")
         else:
             rospy.loginfo("Failed: Invalid parameter entered")
+    currentTemp1 = prevParameterValues.get("PDS_mock_temp1")
+    currentTemp2 = prevParameterValues.get("PDS_mock_temp2")
+    currentTemp3 = prevParameterValues.get("PDS_mock_temp3")
 
-        #Set temperature values for particular parameters
-        for x in range(len(prevTempStates)):
-            if (prevTempStates[x][1] == "high"):
-                prevParameterValues[prevTempStates[x][0]] = temps[0][1]
-            elif (prevTempStates[x][1] == "normal"):
-                prevParameterValues[prevTempStates[x][0]] = temps[1][1]
-            elif (prevTempStates[x][1] == "low"):
-                prevParameterValues[prevTempStates[x][0]] = temps[2][1]
-            else:
-                rospy.loginfo("Failed: Invalid parameter entered")
-        #-------------------------------------------------------------------
-
-        #Get new current voltage and thermistor temps
+    #Acquire parameter settings WHILE ROS IS RUNNING
+    while not rospy.is_shutdown():
+        #Get new current voltage and thermistor temps recursively
         #1) Parameter name
         #2) Parameter's previous value
         #3) Noise
         #4) Increment value
+
         currentVoltage = get_parameter_state(
             "PDS_mock_voltage",
             voltages,
-            prevParameterValues.get("PDS_mock_voltage"),
+            currentVoltage,
             0.05,
-            0.1,
+            0.2,
         )
         currentTemp1 = get_parameter_state(
             "PDS_mock_temp1",
             temps,
-            prevParameterValues.get("PDS_mock_temp1"),
+            currentTemp1,
             0.05,
-            0.1,
+            0.2,
         )
         currentTemp2 = get_parameter_state(
             "PDS_mock_temp2",
             temps,
-            prevParameterValues.get("PDS_mock_temp1"),
+            currentTemp2,
             0.05,
-            0.1,
+            0.2,
         )
         currentTemp3 = get_parameter_state(
             "PDS_mock_temp3",
             temps,
-            prevParameterValues.get("PDS_mock_temp1"),
+            currentTemp3,
             0.05,
-            0.1,
+            0.2,
         )
 
         #Change previous states for voltage and thermistor temps
@@ -160,12 +165,6 @@ def publish_mock_data(voltages, temps):
         prevParameterStates["PDS_mock_temp1"] = rospy.get_param("PDS_mock_temp1")
         prevParameterStates["PDS_mock_temp2"] = rospy.get_param("PDS_mock_temp2")
         prevParameterStates["PDS_mock_temp3"] = rospy.get_param("PDS_mock_temp3")
-
-        #Set data to voltage and thermistortemp types
-        voltage.data = float(currentVoltage)
-        thermistorTemps.therm1 = float(currentTemp1)
-        thermistorTemps.therm2 = float(currentTemp2)
-        thermistorTemps.therm3 = float(currentTemp3)
 
         #Change previous values for voltage and thermistor temps
         prevParameterValues["PDS_mock_voltage"] = currentVoltage
@@ -179,40 +178,31 @@ def publish_mock_data(voltages, temps):
         rospy.loginfo("PDS_mock_temp2 : " + str(prevParameterValues.get("PDS_mock_temp2")))
         rospy.loginfo("PDS_mock_temp3 : " + str(prevParameterValues.get("PDS_mock_temp3")))
 
+        #Set data to voltage and thermistortemp types
+        voltage.data = float(currentVoltage)
+        thermistorTemps.therm1 = float(currentTemp1)
+        thermistorTemps.therm2 = float(currentTemp2)
+        thermistorTemps.therm3 = float(currentTemp3)
+
         #Publish voltage and thermistortemps
         pubVoltage.publish(voltage)
         pubTemp.publish(thermistorTemps)
+
         rate.sleep()
 
 
 if __name__ == '__main__':
 
     #Set voltages high, normal and low to be parametrized
-    voltages = []
-    voltages.append(("high", 20))
-    voltages.append(("normal", 15))
-    voltages.append(("low", 10))
+    voltages = {"high": 20, "normal": 15, "low": 10}
 
     #Set temperatures high, normal and low to be parametrized
-    temps = []
-    temps.append(("high", 100))
-    temps.append(("normal", 50))
-    temps.append(("low", -20))
+    temps = {"high": 100, "normal": 50, "low": -20}
 
-    try:
-        #Initialize parameters for voltage and temperatures
-        rospy.set_param("PDS_mock_voltage", voltages[1][0])
-        rospy.set_param("PDS_mock_temp1", temps[1][0])
-        rospy.set_param("PDS_mock_temp2", temps[1][0])
-        rospy.set_param("PDS_mock_temp3", temps[1][0])
-        rospy.loginfo("Success: Values published")
-    except:
-        rospy.loginfo("Fail: Values not published")
-
-    rospy.loginfo(rospy.get_param("PDS_mock_voltage"))
-    rospy.loginfo(rospy.get_param("PDS_mock_temp1"))
-    rospy.loginfo(rospy.get_param("PDS_mock_temp2"))
-    rospy.loginfo(rospy.get_param("PDS_mock_temp3"))
+    rospy.set_param('PDS_mock_voltage', 'normal')
+    rospy.set_param('PDS_mock_temp1', 'normal')
+    rospy.set_param('PDS_mock_temp2', 'normal')
+    rospy.set_param('PDS_mock_temp3', 'normal')
 
     #Publish all new parameter settings set by user
     try:

--- a/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
@@ -47,12 +47,12 @@ def get_parameter_state(parameterState, values, prevValue, noise, increment):
         sys.exit()
 
     currentGetValue = 0
-    if (param == "high"):
-        currentGetValue = values.get("high")
-    elif (param == "normal"):
-        currentGetValue = values.get("normal")
-    elif (param == "low"):
-        currentGetValue = values.get("low")
+    if (param == "rise"):
+        currentGetValue = values.get("rise")
+    elif (param == "stable"):
+        currentGetValue = values.get("stable")
+    elif (param == "fall"):
+        currentGetValue = values.get("fall")
     else:
         rospy.loginfo("Failed: Invalid parameter entered")
 
@@ -141,24 +141,24 @@ def publish_mock_data(voltages, temps, currents):
     }
 
     #Set initial 1 current voltage
-    if (prevVoltageState == "high"):
-        prevParameterValues["PDS_mock_voltage"] = voltages.get("high")
-    elif (prevVoltageState == "normal"):
-        prevParameterValues["PDS_mock_voltage"] = voltages.get("normal")
-    elif (prevVoltageState == "low"):
-        prevParameterValues["PDS_mock_voltage"] = voltages.get("low")
+    if (prevVoltageState == "rise"):
+        prevParameterValues["PDS_mock_voltage"] = voltages.get("rise")
+    elif (prevVoltageState == "stable"):
+        prevParameterValues["PDS_mock_voltage"] = voltages.get("stable")
+    elif (prevVoltageState == "fall"):
+        prevParameterValues["PDS_mock_voltage"] = voltages.get("fall")
     else:
         rospy.loginfo("Failed: Invalid parameter entered")
     currentVoltage = prevParameterValues.get("PDS_mock_voltage")
 
     #Set initial 3 current temperatures
     for x in range(len(prevTempStates)):
-        if (prevTempStates[x][1] == "high"):
-            prevParameterValues[prevTempStates[x][0]] = temps.get("high")
-        elif (prevTempStates[x][1] == "normal"):
-            prevParameterValues[prevTempStates[x][0]] = temps.get("normal")
-        elif (prevTempStates[x][1] == "low"):
-            prevParameterValues[prevTempStates[x][0]] = temps.get("low")
+        if (prevTempStates[x][1] == "rise"):
+            prevParameterValues[prevTempStates[x][0]] = temps.get("rise")
+        elif (prevTempStates[x][1] == "stable"):
+            prevParameterValues[prevTempStates[x][0]] = temps.get("stable")
+        elif (prevTempStates[x][1] == "fall"):
+            prevParameterValues[prevTempStates[x][0]] = temps.get("fall")
         else:
             rospy.loginfo("Failed: Invalid parameter entered")
     currentTemp1 = prevParameterValues.get("PDS_mock_temp1")
@@ -167,12 +167,12 @@ def publish_mock_data(voltages, temps, currents):
 
     #Set initial 6 current wheel currents
     for x in range(len(prevWheelCurrentStates)):
-        if (prevWheelCurrentStates[x][1] == "high"):
-            prevParameterValues[prevWheelCurrentStates[x][0]] = currents.get("high")
-        elif (prevWheelCurrentStates[x][1] == "normal"):
-            prevParameterValues[prevWheelCurrentStates[x][0]] = currents.get("normal")
-        elif (prevWheelCurrentStates[x][1] == "low"):
-            prevParameterValues[prevWheelCurrentStates[x][0]] = currents.get("low")
+        if (prevWheelCurrentStates[x][1] == "rise"):
+            prevParameterValues[prevWheelCurrentStates[x][0]] = currents.get("rise")
+        elif (prevWheelCurrentStates[x][1] == "stable"):
+            prevParameterValues[prevWheelCurrentStates[x][0]] = currents.get("stable")
+        elif (prevWheelCurrentStates[x][1] == "fall"):
+            prevParameterValues[prevWheelCurrentStates[x][0]] = currents.get("fall")
         else:
             rospy.loginfo("Failed: Invalid parameter entered")
     currentWheelCurrent1 = prevParameterValues.get("PDS_mock_wheel_current1")
@@ -199,19 +199,19 @@ def publish_mock_data(voltages, temps, currents):
             "PDS_mock_wheel_current1", currents, currentWheelCurrent1, 0.05, 0.2
         )
         currentWheelCurrent2 = get_parameter_state(
-            "PDS_mock_wheel_current1", currents, currentWheelCurrent2, 0.05, 0.2
+            "PDS_mock_wheel_current2", currents, currentWheelCurrent2, 0.05, 0.2
         )
         currentWheelCurrent3 = get_parameter_state(
-            "PDS_mock_wheel_current1", currents, currentWheelCurrent3, 0.05, 0.2
+            "PDS_mock_wheel_current3", currents, currentWheelCurrent3, 0.05, 0.2
         )
         currentWheelCurrent4 = get_parameter_state(
-            "PDS_mock_wheel_current1", currents, currentWheelCurrent4, 0.05, 0.2
+            "PDS_mock_wheel_current4", currents, currentWheelCurrent4, 0.05, 0.2
         )
         currentWheelCurrent5 = get_parameter_state(
-            "PDS_mock_wheel_current1", currents, currentWheelCurrent5, 0.05, 0.2
+            "PDS_mock_wheel_current5", currents, currentWheelCurrent5, 0.05, 0.2
         )
         currentWheelCurrent6 = get_parameter_state(
-            "PDS_mock_wheel_current1", currents, currentWheelCurrent6, 0.05, 0.2
+            "PDS_mock_wheel_current6", currents, currentWheelCurrent6, 0.05, 0.2
         )
 
         #Change previous states for evaluated parameters
@@ -265,13 +265,13 @@ def publish_mock_data(voltages, temps, currents):
 if __name__ == '__main__':
 
     #Set voltages high, normal and low to be parametrized
-    voltages = {"high": 20, "normal": 15, "low": 10}
+    voltages = {"rise": 20, "stable": 15, "fall": 10}
 
     #Set temperatures high, normal and low to be parametrized
-    temps = {"high": 100, "normal": 50, "low": -20}
+    temps = {"rise": 100, "stable": 50, "fall": -20}
 
     #Set temperatures high, normal and low to be parametrized
-    currents = {"high": 10, "normal": 5, "low": 0}
+    currents = {"rise": 10, "stable": 5, "fall": 0}
 
     #Publish all new parameter settings set by user
     try:

--- a/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
@@ -5,8 +5,7 @@ import rospy
 import sys
 from std_msgs.msg import Float32
 from geometry_msgs.msg import Point
-from mcu_control.msg import ThermistorTemps as ThermistorTemps
-from mcu_control.msg import Voltage as Voltage
+from mcu_control.msg import ThermistorTemps, Voltage
 from decimal import *
 
 
@@ -26,6 +25,8 @@ class TemperatureMonitor(object):
         self._temps = temps
 
 
+#TODO: Use only ONE get parameter method to get ALL values (scalable)
+#TODO: Take parameterState and values[] instead of voltages[] and temps[]
 def get_voltage_parameter(parameterState, voltages):
     try:
         param = rospy.get_param(parameterState)
@@ -35,10 +36,13 @@ def get_voltage_parameter(parameterState, voltages):
 
     currentGetVoltage = 0
     if (param == "high"):
+        target = voltages[0][1]
         currentGetVoltage = voltages[0][1]
     elif (param == "normal"):
+        target = voltages[1][1]
         currentGetVoltage = voltages[1][1]
     elif (param == "low"):
+        target = voltages[2][1]
         currentGetVoltage = voltages[2][1]
     else:
         rospy.loginfo("Failed: Invalid parameter entered")
@@ -67,90 +71,103 @@ def get_temp_parameter(parameterState, temps):
 
 
 #def publish_mock_data(voltages, temps):
-def publish_mock_data():
+def publish_mock_data(voltages, temps):
 
     #Initialize node
     node_name = "mock_pds_node"
     rospy.init_node(node_name, anonymous=True)
     rospy.loginfo("Initialized: {} node for mock PDS values".format(node_name))
     rate = rospy.Rate(10)
-    pubVoltageTest = rospy.Publisher('battery_voltage', Float32, queue_size=10)
-    pubTempTest = rospy.Publisher('battery_temps', Point, queue_size=10)
+    voltage = Voltage()
+    thermistorTemps = ThermistorTemps()
+    pubVoltage = rospy.Publisher('battery_voltage', Voltage, queue_size=10)
+    pubTemp = rospy.Publisher('battery_temps', ThermistorTemps, queue_size=10)
 
-    #Set voltages high, normal and low to be parametrized
-    voltages = []
-    voltages.append(("high", 20))
-    voltages.append(("normal", 15))
-    voltages.append(("low", 10))
-    #Set temperatures high, normal and low to be parametrized
-    temps = []
-    temps.append(("high", 100))
-    temps.append(("normal", 50))
-    temps.append(("low", -20))
+    # pubVoltageTest = rospy.Publisher('battery_voltage', Float32, queue_size=10)
+    # pubTempTest = rospy.Publisher('battery_temps', Point, queue_size=10)
 
+    #Get previous state before changing parameter
+    prevVoltageState = rospy.get_param("PDS_mock_voltage")
+    prevTemp1State = rospy.get_param("PDS_mock_temp1")
+    prevTemp2State = rospy.get_param("PDS_mock_temp2")
+    prevTemp3State = rospy.get_param("PDS_mock_temp3")
+
+    #Initialize variables for previous voltage and temp
+    prevVoltageValue = None
+    prevTempStates = []
+    prevTempValues = []
+    prevTempStates.append(("PDS_mock_temp1", prevTemp1State))
+    prevTempStates.append(("PDS_mock_temp2", prevTemp2State))
+    prevTempStates.append(("PDS_mock_temp3", prevTemp3State))
+
+    #Set voltage value for particular parameter
+    if (prevVoltageState == "high"):
+        prevVoltageValue = ("PDS_mock_voltage", voltages[0][1])
+    elif (prevVoltageState == "normal"):
+        prevVoltageValue = ("PDS_mock_voltage", voltages[1][1])
+    elif (prevVoltageState == "low"):
+        prevVoltageValue = ("PDS_mock_voltage", voltages[2][1])
+    else:
+        rospy.loginfo("Failed: Invalid parameter entered")
+
+    #Set temperature values for particular parameters
+    for x in range(len(prevTempStates)):
+        if (prevTempStates[x][1] == "high"):
+            prevTempValues.append((prevTempStates[x][0], temps[0][1]))
+        elif (prevTempStates[x][1] == "normal"):
+            prevTempValues.append((prevTempStates[x][0], temps[1][1]))
+        elif (prevTempStates[x][1] == "low"):
+            prevTempValues.append((prevTempStates[x][0], temps[2][1]))
+        else:
+            rospy.loginfo("Failed: Invalid parameter entered")
+
+    rospy.loginfo("Thermistor temp values size: " + str(len(prevTempStates)))
+
+    rospy.loginfo("PDS_mock_voltage : " + str(prevVoltageValue))
+    rospy.loginfo("PDS_mock_temp1 : " + str(prevTempValues[0]))
+    rospy.loginfo("PDS_mock_temp2 : " + str(prevTempValues[1]))
+    rospy.loginfo("PDS_mock_temp3 : " + str(prevTempValues[2]))
+
+    #Acquire parameter settings
     while not rospy.is_shutdown():
         currentVoltage = get_voltage_parameter("PDS_mock_voltage", voltages)
         currentTemp1 = get_temp_parameter("PDS_mock_temp1", temps)
         currentTemp2 = get_temp_parameter("PDS_mock_temp2", temps)
         currentTemp3 = get_temp_parameter("PDS_mock_temp3", temps)
 
-        pubVoltageTest.publish(currentVoltage)
-        pubTempTest.publish(Point(currentTemp1, currentTemp2, currentTemp3))
+        #Set data to voltage and thermistortemp types
+        voltage.data = float(currentVoltage)
+        thermistorTemps.therm1 = float(currentTemp1)
+        thermistorTemps.therm2 = float(currentTemp2)
+        thermistorTemps.therm3 = float(currentTemp3)
+
+        #Publish voltage and thermistortemps
+        pubVoltage.publish(voltage)
+        pubTemp.publish(thermistorTemps)
 
         rate.sleep()
 
 
-# def main():
-
-#     #Initialize node
-#     node_name = "mock_pds_node"
-#     rospy.init_node(node_name, anonymous=True)
-#     rospy.loginfo("Initialized: {} node for mock PDS values".format(node_name))
-#     rate = rospy.Rate(10)
-
-#     pubVoltageTest = rospy.Publisher('battery_voltage', Float32, queue_size=10)
-#     pubTempTest = rospy.Publisher('battery_temps', Float32, queue_size=10)
-
-#     #pubVoltage = rospy.Publisher('battery_voltage', Voltage, queue_size=10)
-#     #pubTemp = rospy.Publisher('battery_temps', ThermistorTemps, queue_size=10)
-
-#     #Set voltages high, normal and low to be parametrized
-#     voltages = []
-#     voltages.append(("high", 20))
-#     voltages.append(("normal", 15))
-#     voltages.append(("low", 10))
-
-#     #Set temperatures high, normal and low to be parametrized
-#     temps = []
-#     temps.append(("high", 100))
-#     temps.append(("normal", 50))
-#     temps.append(("low", -20))
-
-#     #Create objects to publish voltage and temperature
-#     voltageMonitor = VoltageMonitor(pubVoltage, voltages)
-#     tempMonitor = TemperatureMonitor(pubTemp, temps)
-
-#     try:
-#         while not rospy.is_shutdown():
-#             publish_mock_pds_data(voltages, temps)
-#             rate.sleep()
-
-#     except rospy.ROSInterruptException:
-#         pass
-
-#     #Publish values after computing
-#     #pubVoltage.publish(voltages[0])
-#     #pubTemp.publish(temps[0], temps[1], temps[2])
-
-#     #rospy.spin()
-
 if __name__ == '__main__':
+
+    #Set voltages high, normal and low to be parametrized
+    voltages = []
+    voltages.append(("high", 20))
+    voltages.append(("normal", 15))
+    voltages.append(("low", 10))
+
+    #Set temperatures high, normal and low to be parametrized
+    temps = []
+    temps.append(("high", 100))
+    temps.append(("normal", 50))
+    temps.append(("low", -20))
+
     try:
         #Initialize parameters
-        rospy.set_param("PDS_mock_voltage", "high")
-        rospy.set_param("PDS_mock_temp1", "normal")
-        rospy.set_param("PDS_mock_temp2", "normal")
-        rospy.set_param("PDS_mock_temp3", "normal")
+        rospy.set_param("PDS_mock_voltage", voltages[1][0])
+        rospy.set_param("PDS_mock_temp1", temps[1][0])
+        rospy.set_param("PDS_mock_temp2", temps[1][0])
+        rospy.set_param("PDS_mock_temp3", temps[1][0])
         rospy.loginfo("Success: Values published")
     except:
         rospy.loginfo("Fail: Values not published")
@@ -160,43 +177,8 @@ if __name__ == '__main__':
     rospy.loginfo(rospy.get_param("PDS_mock_temp2"))
     rospy.loginfo(rospy.get_param("PDS_mock_temp3"))
 
-    # #Initialize node
-    # node_name = "mock_pds_node"
-    # rospy.init_node(node_name, anonymous=True)
-    # rospy.loginfo("Initialized: {} node for mock PDS values".format(node_name))
-    # rate = rospy.Rate(10)
-    # pubVoltageTest = rospy.Publisher('battery_voltage', Float32, queue_size=10)
-    # pubTempTest = rospy.Publisher('battery_temps', Point, queue_size=10)
-
-    #pubVoltage = rospy.Publisher('battery_voltage', Voltage, queue_size=10)
-    #pubTemp = rospy.Publisher('battery_temps', ThermistorTemps, queue_size=10)
-
-    # #Set voltages high, normal and low to be parametrized
-    # voltages = []
-    # voltages.append(("high", 20))
-    # voltages.append(("normal", 15))
-    # voltages.append(("low", 10))
-
-    ## Set temperatures high, normal and low to be parametrized
-    # temps = []
-    # temps.append(("high", 100))
-    # temps.append(("normal", 50))
-    # temps.append(("low", -20))
-
-    #Create objects to publish voltage and temperature
-    #voltageMonitor = VoltageMonitor(pubVoltage, voltages)
-    #tempMonitor = TemperatureMonitor(pubTemp, temps)
-
-    #voltageMonitor = VoltageMonitor(pubVoltageTest, voltages)
-    #tempMonitor = TemperatureMonitor(pubTempTest, temps)
-
+    #Publish all new parameter settings set by user
     try:
-        publish_mock_data()
-
-        # while not rospy.is_shutdown():
-        #     pubVoltageTest.publish(voltages[2][1])
-        #     pubTempTest.publish(Point(temps[2][1], temps[2][1], temps[2][1]))
-        #     #publish_mock_pds_data(voltages, temps)
-
+        publish_mock_data(voltages, temps)
     except rospy.ROSInterruptException:
         pass

--- a/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
@@ -6,11 +6,39 @@ import sys
 import random
 from std_msgs.msg import Float32
 from geometry_msgs.msg import Point
-from mcu_control.msg import ThermistorTemps, Voltage
+from mcu_control.msg import ThermistorTemps, Voltage, Currents
 from decimal import *
 
 
+#Log all data during publishing (Added in publish_mock_data to see values in CLI)
+def rospyPublishedValueLogger(prevParameterStates, prevParameterValues):
+    #Log new values when posted
+    rospy.loginfo("PDS_mock_voltage : " + str(prevParameterValues.get("PDS_mock_voltage")))
+    rospy.loginfo("PDS_mock_temp1 : " + str(prevParameterValues.get("PDS_mock_temp1")))
+    rospy.loginfo("PDS_mock_temp2 : " + str(prevParameterValues.get("PDS_mock_temp2")))
+    rospy.loginfo("PDS_mock_temp3 : " + str(prevParameterValues.get("PDS_mock_temp3")))
+    rospy.loginfo(
+        "PDS_mock_wheel_current1 : " + str(prevParameterValues.get("PDS_mock_wheel_current1"))
+    )
+    rospy.loginfo(
+        "PDS_mock_wheel_current2 : " + str(prevParameterValues.get("PDS_mock_wheel_current2"))
+    )
+    rospy.loginfo(
+        "PDS_mock_wheel_current3 : " + str(prevParameterValues.get("PDS_mock_wheel_current3"))
+    )
+    rospy.loginfo(
+        "PDS_mock_wheel_current4 : " + str(prevParameterValues.get("PDS_mock_wheel_current4"))
+    )
+    rospy.loginfo(
+        "PDS_mock_wheel_current5 : " + str(prevParameterValues.get("PDS_mock_wheel_current5"))
+    )
+    rospy.loginfo(
+        "PDS_mock_wheel_current6 : " + str(prevParameterValues.get("PDS_mock_wheel_current6"))
+    )
+
+
 #Get parameter state and assign value
+#General function, needs not to be changed
 def get_parameter_state(parameterState, values, prevValue, noise, increment):
     try:
         param = rospy.get_param(parameterState)
@@ -28,7 +56,7 @@ def get_parameter_state(parameterState, values, prevValue, noise, increment):
     else:
         rospy.loginfo("Failed: Invalid parameter entered")
 
-    #Increment to the desired value with noise included
+    #Increment or decrement to the desired value with noise included
     remainder = currentGetValue - prevValue
     if ((abs(remainder) >= (noise + increment))):
         #If negative: increment, if positive: decrement
@@ -41,53 +69,61 @@ def get_parameter_state(parameterState, values, prevValue, noise, increment):
     return prevValue
 
 
-def publish_mock_data(voltages, temps):
+#Get and set parameters to be published
+def publish_mock_data(voltages, temps, currents):
     #Initialize node
     node_name = "mock_pds_node"
     rospy.init_node(node_name, anonymous=True)
     rospy.loginfo("Initialized: {} node for mock PDS values".format(node_name))
     rate = rospy.Rate(10)
+
+    #Initialize publishers (Voltage, ThermistorTemps, Currents)
     voltage = Voltage()
     thermistorTemps = ThermistorTemps()
+    wheelCurrents = Currents()
     pubVoltage = rospy.Publisher('battery_voltage', Voltage, queue_size=10)
     pubTemp = rospy.Publisher('battery_temps', ThermistorTemps, queue_size=10)
+    pubWheelCurrent = rospy.Publisher('wheel_motor_currents', Currents, queue_size=10)
 
-    #Get previous state before changing parameter
+    #Get previous states before changing parameters for each individual
     prevVoltageState = rospy.get_param("PDS_mock_voltage")
     prevTemp1State = rospy.get_param("PDS_mock_temp1")
     prevTemp2State = rospy.get_param("PDS_mock_temp2")
     prevTemp3State = rospy.get_param("PDS_mock_temp3")
-
-    # #Initialize starting state on program startup
-    # prevVoltageState = "normal"
-    # prevTemp1State = "normal"
-    # prevTemp2State = "normal"
-    # prevTemp3State = "normal"
-
-    # #Set data to voltage and thermistortemp types
-    # voltage.data = float(currentVoltage)
-    # thermistorTemps.therm1 = float(currentTemp1)
-    # thermistorTemps.therm2 = float(currentTemp2)
-    # thermistorTemps.therm3 = float(currentTemp3)
-
-    # #Publish voltage and thermistortemps
-    # pubVoltage.publish(voltage)
-    # pubTemp.publish(thermistorTemps)
-
-    #Initialize variables for previous voltage and temp
-    prevTempStates = []
+    prevWheelCurrent1State = rospy.get_param("PDS_mock_wheel_current1")
+    prevWheelCurrent2State = rospy.get_param("PDS_mock_wheel_current2")
+    prevWheelCurrent3State = rospy.get_param("PDS_mock_wheel_current3")
+    prevWheelCurrent4State = rospy.get_param("PDS_mock_wheel_current4")
+    prevWheelCurrent5State = rospy.get_param("PDS_mock_wheel_current5")
+    prevWheelCurrent6State = rospy.get_param("PDS_mock_wheel_current6")
 
     #Create list of temperatures to loop through when assigning new temperatures
+    prevTempStates = []
     prevTempStates.append(("PDS_mock_temp1", prevTemp1State))
     prevTempStates.append(("PDS_mock_temp2", prevTemp2State))
     prevTempStates.append(("PDS_mock_temp3", prevTemp3State))
+
+    #Create list of wheel currents to loop through when assigning new currents
+    prevWheelCurrentStates = []
+    prevWheelCurrentStates.append(("PDS_mock_wheel_current1", prevWheelCurrent1State))
+    prevWheelCurrentStates.append(("PDS_mock_wheel_current2", prevWheelCurrent2State))
+    prevWheelCurrentStates.append(("PDS_mock_wheel_current3", prevWheelCurrent3State))
+    prevWheelCurrentStates.append(("PDS_mock_wheel_current4", prevWheelCurrent4State))
+    prevWheelCurrentStates.append(("PDS_mock_wheel_current5", prevWheelCurrent5State))
+    prevWheelCurrentStates.append(("PDS_mock_wheel_current6", prevWheelCurrent6State))
 
     #Create dict with all parameter states (easily append to for scalability)
     prevParameterStates = {
         "PDS_mock_voltage": prevVoltageState,
         "PDS_mock_temp1": prevTemp1State,
         "PDS_mock_temp2": prevTemp2State,
-        "PDS_mock_temp3": prevTemp3State
+        "PDS_mock_temp3": prevTemp3State,
+        "PDS_mock_wheel_current1": prevWheelCurrent1State,
+        "PDS_mock_wheel_current2": prevWheelCurrent2State,
+        "PDS_mock_wheel_current3": prevWheelCurrent3State,
+        "PDS_mock_wheel_current4": prevWheelCurrent4State,
+        "PDS_mock_wheel_current5": prevWheelCurrent5State,
+        "PDS_mock_wheel_current6": prevWheelCurrent6State
     }
 
     #Create dict with all parameter values (easily append to for scalability)
@@ -95,10 +131,16 @@ def publish_mock_data(voltages, temps):
         "PDS_mock_voltage": None,
         "PDS_mock_temp1": None,
         "PDS_mock_temp2": None,
-        "PDS_mock_temp3": None
+        "PDS_mock_temp3": None,
+        "PDS_mock_wheel_current1": None,
+        "PDS_mock_wheel_current2": None,
+        "PDS_mock_wheel_current3": None,
+        "PDS_mock_wheel_current4": None,
+        "PDS_mock_wheel_current5": None,
+        "PDS_mock_wheel_current6": None
     }
 
-    #Set initial current voltage
+    #Set initial 1 current voltage
     if (prevVoltageState == "high"):
         prevParameterValues["PDS_mock_voltage"] = voltages.get("high")
     elif (prevVoltageState == "normal"):
@@ -123,71 +165,100 @@ def publish_mock_data(voltages, temps):
     currentTemp2 = prevParameterValues.get("PDS_mock_temp2")
     currentTemp3 = prevParameterValues.get("PDS_mock_temp3")
 
-    #Acquire parameter settings WHILE ROS IS RUNNING
+    #Set initial 6 current wheel currents
+    for x in range(len(prevWheelCurrentStates)):
+        if (prevWheelCurrentStates[x][1] == "high"):
+            prevParameterValues[prevWheelCurrentStates[x][0]] = currents.get("high")
+        elif (prevWheelCurrentStates[x][1] == "normal"):
+            prevParameterValues[prevWheelCurrentStates[x][0]] = currents.get("normal")
+        elif (prevWheelCurrentStates[x][1] == "low"):
+            prevParameterValues[prevWheelCurrentStates[x][0]] = currents.get("low")
+        else:
+            rospy.loginfo("Failed: Invalid parameter entered")
+    currentWheelCurrent1 = prevParameterValues.get("PDS_mock_wheel_current1")
+    currentWheelCurrent2 = prevParameterValues.get("PDS_mock_wheel_current2")
+    currentWheelCurrent3 = prevParameterValues.get("PDS_mock_wheel_current3")
+    currentWheelCurrent4 = prevParameterValues.get("PDS_mock_wheel_current4")
+    currentWheelCurrent5 = prevParameterValues.get("PDS_mock_wheel_current5")
+    currentWheelCurrent6 = prevParameterValues.get("PDS_mock_wheel_current6")
+
+    #Acquire and set parameters while launch file is active
     while not rospy.is_shutdown():
         #Get new current voltage and thermistor temps recursively
         #1) Parameter name
         #2) Parameter's previous value
-        #3) Noise
+        #3) Noise value
         #4) Increment value
-
         currentVoltage = get_parameter_state(
-            "PDS_mock_voltage",
-            voltages,
-            currentVoltage,
-            0.05,
-            0.2,
+            "PDS_mock_voltage", voltages, currentVoltage, 0.05, 0.2
         )
-        currentTemp1 = get_parameter_state(
-            "PDS_mock_temp1",
-            temps,
-            currentTemp1,
-            0.05,
-            0.2,
+        currentTemp1 = get_parameter_state("PDS_mock_temp1", temps, currentTemp1, 0.05, 0.2)
+        currentTemp2 = get_parameter_state("PDS_mock_temp2", temps, currentTemp2, 0.05, 0.2)
+        currentTemp3 = get_parameter_state("PDS_mock_temp3", temps, currentTemp3, 0.05, 0.2)
+        currentWheelCurrent1 = get_parameter_state(
+            "PDS_mock_wheel_current1", currents, currentWheelCurrent1, 0.05, 0.2
         )
-        currentTemp2 = get_parameter_state(
-            "PDS_mock_temp2",
-            temps,
-            currentTemp2,
-            0.05,
-            0.2,
+        currentWheelCurrent2 = get_parameter_state(
+            "PDS_mock_wheel_current1", currents, currentWheelCurrent2, 0.05, 0.2
         )
-        currentTemp3 = get_parameter_state(
-            "PDS_mock_temp3",
-            temps,
-            currentTemp3,
-            0.05,
-            0.2,
+        currentWheelCurrent3 = get_parameter_state(
+            "PDS_mock_wheel_current1", currents, currentWheelCurrent3, 0.05, 0.2
+        )
+        currentWheelCurrent4 = get_parameter_state(
+            "PDS_mock_wheel_current1", currents, currentWheelCurrent4, 0.05, 0.2
+        )
+        currentWheelCurrent5 = get_parameter_state(
+            "PDS_mock_wheel_current1", currents, currentWheelCurrent5, 0.05, 0.2
+        )
+        currentWheelCurrent6 = get_parameter_state(
+            "PDS_mock_wheel_current1", currents, currentWheelCurrent6, 0.05, 0.2
         )
 
-        #Change previous states for voltage and thermistor temps
+        #Change previous states for evaluated parameters
         prevParameterStates["PDS_mock_voltage"] = rospy.get_param("PDS_mock_voltage")
         prevParameterStates["PDS_mock_temp1"] = rospy.get_param("PDS_mock_temp1")
         prevParameterStates["PDS_mock_temp2"] = rospy.get_param("PDS_mock_temp2")
         prevParameterStates["PDS_mock_temp3"] = rospy.get_param("PDS_mock_temp3")
+        prevParameterStates["PDS_mock_wheel_current1"] = rospy.get_param("PDS_mock_wheel_current1")
+        prevParameterStates["PDS_mock_wheel_current2"] = rospy.get_param("PDS_mock_wheel_current2")
+        prevParameterStates["PDS_mock_wheel_current3"] = rospy.get_param("PDS_mock_wheel_current3")
+        prevParameterStates["PDS_mock_wheel_current4"] = rospy.get_param("PDS_mock_wheel_current4")
+        prevParameterStates["PDS_mock_wheel_current5"] = rospy.get_param("PDS_mock_wheel_current5")
+        prevParameterStates["PDS_mock_wheel_current6"] = rospy.get_param("PDS_mock_wheel_current6")
 
         #Change previous values for voltage and thermistor temps
         prevParameterValues["PDS_mock_voltage"] = currentVoltage
         prevParameterValues["PDS_mock_temp1"] = currentTemp1
         prevParameterValues["PDS_mock_temp2"] = currentTemp2
         prevParameterValues["PDS_mock_temp3"] = currentTemp3
+        prevParameterValues["PDS_mock_wheel_current1"] = currentWheelCurrent1
+        prevParameterValues["PDS_mock_wheel_current2"] = currentWheelCurrent2
+        prevParameterValues["PDS_mock_wheel_current3"] = currentWheelCurrent3
+        prevParameterValues["PDS_mock_wheel_current4"] = currentWheelCurrent4
+        prevParameterValues["PDS_mock_wheel_current5"] = currentWheelCurrent5
+        prevParameterValues["PDS_mock_wheel_current6"] = currentWheelCurrent6
 
-        #Log new values when posted
-        rospy.loginfo("PDS_mock_voltage : " + str(prevParameterValues.get("PDS_mock_voltage")))
-        rospy.loginfo("PDS_mock_temp1 : " + str(prevParameterValues.get("PDS_mock_temp1")))
-        rospy.loginfo("PDS_mock_temp2 : " + str(prevParameterValues.get("PDS_mock_temp2")))
-        rospy.loginfo("PDS_mock_temp3 : " + str(prevParameterValues.get("PDS_mock_temp3")))
+        #Add to see published values in CLI, or comment out if not needed
+        rospyPublishedValueLogger(prevParameterStates, prevParameterValues)
 
-        #Set data to voltage and thermistortemp types
+        #Set valus to objects which will get published
         voltage.data = float(currentVoltage)
         thermistorTemps.therm1 = float(currentTemp1)
         thermistorTemps.therm2 = float(currentTemp2)
         thermistorTemps.therm3 = float(currentTemp3)
+        wheelCurrents.effort.append(float(currentWheelCurrent1))
+        wheelCurrents.effort.append(float(currentWheelCurrent2))
+        wheelCurrents.effort.append(float(currentWheelCurrent3))
+        wheelCurrents.effort.append(float(currentWheelCurrent4))
+        wheelCurrents.effort.append(float(currentWheelCurrent5))
+        wheelCurrents.effort.append(float(currentWheelCurrent6))
 
-        #Publish voltage and thermistortemps
+        #Publish values to topics (Voltage, ThermistorTemps and Currents)
         pubVoltage.publish(voltage)
         pubTemp.publish(thermistorTemps)
+        pubWheelCurrent.publish(wheelCurrents)
 
+        #Add delay before each iteration
         rate.sleep()
 
 
@@ -199,13 +270,11 @@ if __name__ == '__main__':
     #Set temperatures high, normal and low to be parametrized
     temps = {"high": 100, "normal": 50, "low": -20}
 
-    rospy.set_param('PDS_mock_voltage', 'normal')
-    rospy.set_param('PDS_mock_temp1', 'normal')
-    rospy.set_param('PDS_mock_temp2', 'normal')
-    rospy.set_param('PDS_mock_temp3', 'normal')
+    #Set temperatures high, normal and low to be parametrized
+    currents = {"high": 10, "normal": 5, "low": 0}
 
     #Publish all new parameter settings set by user
     try:
-        publish_mock_data(voltages, temps)
+        publish_mock_data(voltages, temps, currents)
     except rospy.ROSInterruptException:
         pass

--- a/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
@@ -8,13 +8,14 @@ from std_msgs.msg import Float32
 from geometry_msgs.msg import Point
 from mcu_control.msg import ThermistorTemps, Voltage, Currents
 from decimal import *
-"""Log all data during publishing
+
+
+def rospyPublishedValueLogger(prevParameterStates, prevParameterValues):
+    """Log all data during publishing
     Add to publish_mock_data to log published data in CLI
     Remove from publish_mock_data if not needed
     Used for testing purposes"""
 
-
-def rospyPublishedValueLogger(prevParameterStates, prevParameterValues):
     #Log new values when posted
     rospy.loginfo("PDS_mock_voltage : " + str(prevParameterValues.get("PDS_mock_voltage")))
     rospy.loginfo("PDS_mock_temp1 : " + str(prevParameterValues.get("PDS_mock_temp1")))
@@ -40,11 +41,10 @@ def rospyPublishedValueLogger(prevParameterStates, prevParameterValues):
     )
 
 
-"""Get parameter state and assign value
-General function, needs not to be changed"""
-
-
 def get_parameter_state(parameterState, values, prevValue, noise, increment):
+    """Get parameter state and assign value
+    General function, needs not to be changed"""
+
     try:
         param = rospy.get_param(parameterState)
     except:
@@ -74,10 +74,9 @@ def get_parameter_state(parameterState, values, prevValue, noise, increment):
     return prevValue
 
 
-"""Get and set parameters to be published"""
-
-
 def publish_mock_data(voltages, temps, currents):
+    """Get and set parameters to be published"""
+
     #Initialize node
     node_name = "mock_pds_node"
     rospy.init_node(node_name, anonymous=True)
@@ -189,15 +188,14 @@ def publish_mock_data(voltages, temps, currents):
     currentWheelCurrent5 = prevParameterValues.get("PDS_mock_wheel_current5")
     currentWheelCurrent6 = prevParameterValues.get("PDS_mock_wheel_current6")
 
-    # Acquire and set parameters while launch file is active
+    # Acquire parameter and set parameter states while launch file is active
     while not rospy.is_shutdown():
-        """
-        Get new current voltage and thermistor temps recursively
+        """Get new current, voltage, and thermistor temps recursively
         1) Parameter name
         2) Parameter's previous value
         3) Noise value
-        4) Increment value
-        """
+        4) Increment value"""
+
         currentVoltage = get_parameter_state(
             "PDS_mock_voltage", voltages, currentVoltage, 0.05, 0.2
         )
@@ -272,6 +270,9 @@ def publish_mock_data(voltages, temps, currents):
 
 
 if __name__ == '__main__':
+    """Calls publisher function and passes parameter settings
+    Change the values for the parameter states (rise, stable and fall) here (i.e. voltages, temps and currents)
+    No other places require to be modified to change the state values"""
 
     #Set voltages high, normal and low to be parametrized
     voltages = {"rise": 20, "stable": 15, "fall": 10}

--- a/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
@@ -1,0 +1,202 @@
+#! /usr/bin/env python3
+
+import time
+import rospy
+import sys
+from std_msgs.msg import Float32
+from geometry_msgs.msg import Point
+from mcu_control.msg import ThermistorTemps as ThermistorTemps
+from mcu_control.msg import Voltage as Voltage
+from decimal import *
+
+
+class VoltageMonitor(object):
+
+    def __init__(self, pub, voltages):
+        self._pub = pub
+        self._voltages = voltages
+
+    # def callback(self, msg):
+
+
+class TemperatureMonitor(object):
+
+    def __init__(self, pub, temps):
+        self._pub = pub
+        self._temps = temps
+
+
+def get_voltage_parameter(parameterState, voltages):
+    try:
+        param = rospy.get_param(parameterState)
+    except:
+        rospy.loginfo("Failed: Voltage parameter not acquired.")
+        sys.exit()
+
+    currentGetVoltage = 0
+    if (param == "high"):
+        currentGetVoltage = voltages[0][1]
+    elif (param == "normal"):
+        currentGetVoltage = voltages[1][1]
+    elif (param == "low"):
+        currentGetVoltage = voltages[2][1]
+    else:
+        rospy.loginfo("Failed: Invalid parameter entered")
+
+    return currentGetVoltage
+
+
+def get_temp_parameter(parameterState, temps):
+    try:
+        param = rospy.get_param(parameterState)
+    except:
+        rospy.loginfo("Failed: Temperature parameter not acquired.")
+        sys.exit()
+
+    currentGetTemp = 0
+    if (param == "high"):
+        currentGetTemp = temps[0][1]
+    elif (param == "normal"):
+        currentGetTemp = temps[1][1]
+    elif (param == "low"):
+        currentGetTemp = temps[2][1]
+    else:
+        rospy.loginfo("Failed: Invalid parameter entered")
+
+    return currentGetTemp
+
+
+#def publish_mock_data(voltages, temps):
+def publish_mock_data():
+
+    #Initialize node
+    node_name = "mock_pds_node"
+    rospy.init_node(node_name, anonymous=True)
+    rospy.loginfo("Initialized: {} node for mock PDS values".format(node_name))
+    rate = rospy.Rate(10)
+    pubVoltageTest = rospy.Publisher('battery_voltage', Float32, queue_size=10)
+    pubTempTest = rospy.Publisher('battery_temps', Point, queue_size=10)
+
+    #Set voltages high, normal and low to be parametrized
+    voltages = []
+    voltages.append(("high", 20))
+    voltages.append(("normal", 15))
+    voltages.append(("low", 10))
+    #Set temperatures high, normal and low to be parametrized
+    temps = []
+    temps.append(("high", 100))
+    temps.append(("normal", 50))
+    temps.append(("low", -20))
+
+    while not rospy.is_shutdown():
+        currentVoltage = get_voltage_parameter("PDS_mock_voltage", voltages)
+        currentTemp1 = get_temp_parameter("PDS_mock_temp1", temps)
+        currentTemp2 = get_temp_parameter("PDS_mock_temp2", temps)
+        currentTemp3 = get_temp_parameter("PDS_mock_temp3", temps)
+
+        pubVoltageTest.publish(currentVoltage)
+        pubTempTest.publish(Point(currentTemp1, currentTemp2, currentTemp3))
+
+        rate.sleep()
+
+
+# def main():
+
+#     #Initialize node
+#     node_name = "mock_pds_node"
+#     rospy.init_node(node_name, anonymous=True)
+#     rospy.loginfo("Initialized: {} node for mock PDS values".format(node_name))
+#     rate = rospy.Rate(10)
+
+#     pubVoltageTest = rospy.Publisher('battery_voltage', Float32, queue_size=10)
+#     pubTempTest = rospy.Publisher('battery_temps', Float32, queue_size=10)
+
+#     #pubVoltage = rospy.Publisher('battery_voltage', Voltage, queue_size=10)
+#     #pubTemp = rospy.Publisher('battery_temps', ThermistorTemps, queue_size=10)
+
+#     #Set voltages high, normal and low to be parametrized
+#     voltages = []
+#     voltages.append(("high", 20))
+#     voltages.append(("normal", 15))
+#     voltages.append(("low", 10))
+
+#     #Set temperatures high, normal and low to be parametrized
+#     temps = []
+#     temps.append(("high", 100))
+#     temps.append(("normal", 50))
+#     temps.append(("low", -20))
+
+#     #Create objects to publish voltage and temperature
+#     voltageMonitor = VoltageMonitor(pubVoltage, voltages)
+#     tempMonitor = TemperatureMonitor(pubTemp, temps)
+
+#     try:
+#         while not rospy.is_shutdown():
+#             publish_mock_pds_data(voltages, temps)
+#             rate.sleep()
+
+#     except rospy.ROSInterruptException:
+#         pass
+
+#     #Publish values after computing
+#     #pubVoltage.publish(voltages[0])
+#     #pubTemp.publish(temps[0], temps[1], temps[2])
+
+#     #rospy.spin()
+
+if __name__ == '__main__':
+    try:
+        #Initialize parameters
+        rospy.set_param("PDS_mock_voltage", "high")
+        rospy.set_param("PDS_mock_temp1", "normal")
+        rospy.set_param("PDS_mock_temp2", "normal")
+        rospy.set_param("PDS_mock_temp3", "normal")
+        rospy.loginfo("Success: Values published")
+    except:
+        rospy.loginfo("Fail: Values not published")
+
+    rospy.loginfo(rospy.get_param("PDS_mock_voltage"))
+    rospy.loginfo(rospy.get_param("PDS_mock_temp1"))
+    rospy.loginfo(rospy.get_param("PDS_mock_temp2"))
+    rospy.loginfo(rospy.get_param("PDS_mock_temp3"))
+
+    # #Initialize node
+    # node_name = "mock_pds_node"
+    # rospy.init_node(node_name, anonymous=True)
+    # rospy.loginfo("Initialized: {} node for mock PDS values".format(node_name))
+    # rate = rospy.Rate(10)
+    # pubVoltageTest = rospy.Publisher('battery_voltage', Float32, queue_size=10)
+    # pubTempTest = rospy.Publisher('battery_temps', Point, queue_size=10)
+
+    #pubVoltage = rospy.Publisher('battery_voltage', Voltage, queue_size=10)
+    #pubTemp = rospy.Publisher('battery_temps', ThermistorTemps, queue_size=10)
+
+    # #Set voltages high, normal and low to be parametrized
+    # voltages = []
+    # voltages.append(("high", 20))
+    # voltages.append(("normal", 15))
+    # voltages.append(("low", 10))
+
+    ## Set temperatures high, normal and low to be parametrized
+    # temps = []
+    # temps.append(("high", 100))
+    # temps.append(("normal", 50))
+    # temps.append(("low", -20))
+
+    #Create objects to publish voltage and temperature
+    #voltageMonitor = VoltageMonitor(pubVoltage, voltages)
+    #tempMonitor = TemperatureMonitor(pubTemp, temps)
+
+    #voltageMonitor = VoltageMonitor(pubVoltageTest, voltages)
+    #tempMonitor = TemperatureMonitor(pubTempTest, temps)
+
+    try:
+        publish_mock_data()
+
+        # while not rospy.is_shutdown():
+        #     pubVoltageTest.publish(voltages[2][1])
+        #     pubTempTest.publish(Point(temps[2][1], temps[2][1], temps[2][1]))
+        #     #publish_mock_pds_data(voltages, temps)
+
+    except rospy.ROSInterruptException:
+        pass

--- a/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
+++ b/robot/rospackages/src/mcu_control/scripts/MockPdsNode.py
@@ -8,12 +8,12 @@ from std_msgs.msg import Float32
 from geometry_msgs.msg import Point
 from mcu_control.msg import ThermistorTemps, Voltage, Currents
 from decimal import *
+"""Log all data during publishing
+    Add to publish_mock_data to log published data in CLI
+    Remove from publish_mock_data if not needed
+    Used for testing purposes"""
 
 
-#Log all data during publishing
-#Add to publish_mock_data to log published data in CLI
-#Remove from publish_mock_data if not needed
-#Used for testing purposes
 def rospyPublishedValueLogger(prevParameterStates, prevParameterValues):
     #Log new values when posted
     rospy.loginfo("PDS_mock_voltage : " + str(prevParameterValues.get("PDS_mock_voltage")))
@@ -40,8 +40,10 @@ def rospyPublishedValueLogger(prevParameterStates, prevParameterValues):
     )
 
 
-#Get parameter state and assign value
-#General function, needs not to be changed
+"""Get parameter state and assign value
+General function, needs not to be changed"""
+
+
 def get_parameter_state(parameterState, values, prevValue, noise, increment):
     try:
         param = rospy.get_param(parameterState)
@@ -72,7 +74,9 @@ def get_parameter_state(parameterState, values, prevValue, noise, increment):
     return prevValue
 
 
-#Get and set parameters to be published
+"""Get and set parameters to be published"""
+
+
 def publish_mock_data(voltages, temps, currents):
     #Initialize node
     node_name = "mock_pds_node"
@@ -185,13 +189,15 @@ def publish_mock_data(voltages, temps, currents):
     currentWheelCurrent5 = prevParameterValues.get("PDS_mock_wheel_current5")
     currentWheelCurrent6 = prevParameterValues.get("PDS_mock_wheel_current6")
 
-    #Acquire and set parameters while launch file is active
+    # Acquire and set parameters while launch file is active
     while not rospy.is_shutdown():
-        #Get new current voltage and thermistor temps recursively
-        #1) Parameter name
-        #2) Parameter's previous value
-        #3) Noise value
-        #4) Increment value
+        """
+        Get new current voltage and thermistor temps recursively
+        1) Parameter name
+        2) Parameter's previous value
+        3) Noise value
+        4) Increment value
+        """
         currentVoltage = get_parameter_state(
             "PDS_mock_voltage", voltages, currentVoltage, 0.05, 0.2
         )

--- a/robot/util/rosRoverStart/local_rover.launch
+++ b/robot/util/rosRoverStart/local_rover.launch
@@ -3,14 +3,14 @@
     <node pkg="web_video_server" type="web_video_server" name="web_video_server" output="screen"/>    
     <node pkg="task_handler" type="task_handler_server.py" name="task_handler_server" output="screen" args="local"/>
     <node pkg="mcu_control" type="MockPdsNode.py" name="mock_pds_node" output="screen"/>
-    <param name="PDS_mock_voltage" value="normal"/>
-    <param name="PDS_mock_temp1" value="normal"/>
-    <param name="PDS_mock_temp2" value="normal"/>
-    <param name="PDS_mock_temp3" value="normal"/>
-    <param name="PDS_mock_wheel_current1" value="normal"/>
-    <param name="PDS_mock_wheel_current2" value="normal"/>
-    <param name="PDS_mock_wheel_current3" value="normal"/>
-    <param name="PDS_mock_wheel_current4" value="normal"/>
-    <param name="PDS_mock_wheel_current5" value="normal"/>
-    <param name="PDS_mock_wheel_current6" value="normal"/>
+    <param name="PDS_mock_voltage" value="stable"/>
+    <param name="PDS_mock_temp1" value="stable"/>
+    <param name="PDS_mock_temp2" value="stable"/>
+    <param name="PDS_mock_temp3" value="stable"/>
+    <param name="PDS_mock_wheel_current1" value="stable"/>
+    <param name="PDS_mock_wheel_current2" value="stable"/>
+    <param name="PDS_mock_wheel_current3" value="stable"/>
+    <param name="PDS_mock_wheel_current4" value="stable"/>
+    <param name="PDS_mock_wheel_current5" value="stable"/>
+    <param name="PDS_mock_wheel_current6" value="stable"/>
 </launch>

--- a/robot/util/rosRoverStart/local_rover.launch
+++ b/robot/util/rosRoverStart/local_rover.launch
@@ -2,6 +2,15 @@
     <node pkg="mux_selector" type="mux_select_server.py" name="mux_select_server" output="screen" args="local"/>
     <node pkg="web_video_server" type="web_video_server" name="web_video_server" output="screen"/>    
     <node pkg="task_handler" type="task_handler_server.py" name="task_handler_server" output="screen" args="local"/>
-    <!-- <node pkg="mcu_control" type="localPDSMockPublisher.py" name="PDS_mock_pub" output="screen"/> -->
     <node pkg="mcu_control" type="MockPdsNode.py" name="mock_pds_node" output="screen"/>
+    <param name="PDS_mock_voltage" value="normal"/>
+    <param name="PDS_mock_temp1" value="normal"/>
+    <param name="PDS_mock_temp2" value="normal"/>
+    <param name="PDS_mock_temp3" value="normal"/>
+    <param name="PDS_mock_wheel_current1" value="normal"/>
+    <param name="PDS_mock_wheel_current2" value="normal"/>
+    <param name="PDS_mock_wheel_current3" value="normal"/>
+    <param name="PDS_mock_wheel_current4" value="normal"/>
+    <param name="PDS_mock_wheel_current5" value="normal"/>
+    <param name="PDS_mock_wheel_current6" value="normal"/>
 </launch>

--- a/robot/util/rosRoverStart/local_rover.launch
+++ b/robot/util/rosRoverStart/local_rover.launch
@@ -2,4 +2,6 @@
     <node pkg="mux_selector" type="mux_select_server.py" name="mux_select_server" output="screen" args="local"/>
     <node pkg="web_video_server" type="web_video_server" name="web_video_server" output="screen"/>    
     <node pkg="task_handler" type="task_handler_server.py" name="task_handler_server" output="screen" args="local"/>
+    <!-- <node pkg="mcu_control" type="localPDSMockPublisher.py" name="PDS_mock_pub" output="screen"/> -->
+    <node pkg="mcu_control" type="MockPdsNode.py" name="mock_pds_node" output="screen"/>
 </launch>


### PR DESCRIPTION

## Description
Changes made to be able to display battery_temps values onto GUI. Previously, the values were never displayed and remained constantly as "NaN" as opposed to their published values. This fixes the bug where values were never properly displayed on the GUI. 

### Steps for Testing
1. Run rosgui and startgui in two terminal windows simultaneously.
2. Open the GUI on http://localhost:5000.
3. In terminal, publish a set of 3 battery temperatures using: `rostopic pub /battery_temps mcu_control/ThermistorTemps "therm1: <value1> therm2: <value2> therm3: <value3>"`
4. Observe the values displayed on the GUI.

closes #433 