### PR TITLE
[#433] Fix battery_temp ThermistorTemps values displayed on the GUI 

### DIFF
--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -244,9 +244,9 @@ function initRosWeb () {
   battery_temps_listener.subscribe(function (message) {
     // sets temperatures to two decimal points
     let temps = [
-      parseFloat(message.x).toFixed(2),
-      parseFloat(message.y).toFixed(2),
-      parseFloat(message.z).toFixed(2)
+      parseFloat(message.therm1).toFixed(2),
+      parseFloat(message.therm2).toFixed(2),
+      parseFloat(message.therm3).toFixed(2)
     ]
 
     $('.battery-temp').each(function(i, obj) {


### PR DESCRIPTION

## Description
Changes made to be able to display battery_temps values onto GUI. Previously, the values were never displayed and remained constantly as "NaN" as opposed to their published values. This fixes the bug where values were never properly displayed on the GUI.

### Steps for Testing
1. Run `rosgui` and `startgui` in two terminal windows simultaneously.
2. Open the GUI on http://localhost:5000.
3. In terminal, publish a set of 3 battery temperatures using: `rostopic pub /battery_temps mcu_control/ThermistorTemps "therm1: <value1> therm2: <value2> therm3: <value3>"`
4. Observe the values displayed on the GUI.

Closes #433 