### PR TITLE
Docker build optimizations 475

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -56,3 +56,7 @@ robot/rover/science/MakeFile
 robot/rover/science/cmake_install.cmake
 robot/rover/science/science.ino.cpp
 robot/rover/cmake_install.cmake
+.git
+**/*.gitignore
+**/*.gitmodules
+**/*.md

--- a/docker/rosbridge/Dockerfile
+++ b/docker/rosbridge/Dockerfile
@@ -1,10 +1,18 @@
 FROM ros:melodic-ros-core
 
 SHELL ["/bin/bash", "-c"]
+
+# $USER env variable used in some of the scripts
+ENV USER spaceuser 
+
 RUN apt-get update && apt-get install -y ros-melodic-rosbridge-suite \
     && useradd --create-home --groups sudo --shell /bin/bash spaceuser \
     && echo -e 'spaceuser\nspaceuser' | passwd spaceuser \
-    && mkdir -p /home/spaceuser/Programming/robotics-prototype
+    && mkdir -p /home/spaceuser/Programming/robotics-prototype \
+    && echo "source /opt/ros/melodic/setup.bash" >> /home/spaceuser/.bashrc \
+    && echo "source /home/spaceuser/Programming/robotics-prototype/robot/rospackages/devel/setup.bash" >> /home/spaceuser/.bashrc \
+    && echo "source /home/spaceuser/Programming/robotics-prototype/robot/basestation/config/.bash_aliases" >> /home/spaceuser/.bashrc \
+    && echo "source /home/spaceuser/Programming/robotics-prototype/robot/rover/config/.bash_aliases" >> /home/spaceuser/.bashrc 
 
 
 WORKDIR /home/spaceuser/Programming/robotics-prototype
@@ -19,35 +27,36 @@ RUN apt-get update && apt-get install -y python3-pip \
 RUN apt-get update -y && apt-get upgrade -y \
     && apt-get install -y nano vim wget curl libfontconfig libx11-6 libxft2
 
-COPY . .
-WORKDIR /home/spaceuser/Programming/robotics-prototype/robot/rospackages
-RUN rosdep init \
-    && rosdep update --rosdistro $ROS_DISTRO \
-    && rosdep install --from-paths src/ --ignore-src -r -y \
-    && source /opt/ros/$ROS_DISTRO/setup.sh \
-    && catkin_make -DPYTHON_EXECUTABLE=/usr/bin/python3 \
-    && chown -R spaceuser:spaceuser /home/spaceuser/Programming \
-    && chmod u+x /home/spaceuser/Programming/robotics-prototype/entrypoint.sh
+COPY install_arduino_teensyduino.sh .
 
 USER spaceuser
+RUN echo 'spaceuser' | sudo -S /home/spaceuser/Programming/robotics-prototype/install_arduino_teensyduino.sh 
 
-# $USER env variable used in some of the scripts
-ENV USER spaceuser 
-
+COPY robot/rover ./robot/rover
 WORKDIR /home/spaceuser/Programming/robotics-prototype/robot/rover
-
-RUN echo 'spaceuser' | sudo -S /home/spaceuser/Programming/robotics-prototype/install_arduino_teensyduino.sh \
-    && echo 'spaceuser' | sudo -S chown -R spaceuser:spaceuser /home/spaceuser \
+RUN echo 'spaceuser' | sudo -S chown -R spaceuser:spaceuser /home/spaceuser \
     && tail -n1 /home/spaceuser/.bashrc > /home/spaceuser/.tmprc \
     && source /home/spaceuser/.tmprc \
     && cmake . \
     && make -j$(nproc) \
     && rm /home/spaceuser/.tmprc
 
+USER root
 WORKDIR /home/spaceuser/Programming/robotics-prototype
-RUN echo "source /opt/ros/melodic/setup.bash" >> /home/spaceuser/.bashrc \
-    && echo "source /home/spaceuser/Programming/robotics-prototype/robot/rospackages/devel/setup.bash" >> /home/spaceuser/.bashrc \
-    && echo "source /home/spaceuser/Programming/robotics-prototype/robot/basestation/config/.bash_aliases" >> /home/spaceuser/.bashrc \
-    && echo "source /home/spaceuser/Programming/robotics-prototype/robot/rover/config/.bash_aliases" >> /home/spaceuser/.bashrc 
+COPY robot/rospackages ./robot/rospackages
+RUN rosdep init \
+    && rosdep update --rosdistro $ROS_DISTRO \
+    && rosdep install --from-paths robot/rospackages/src/ --ignore-src -r -y 
+
+COPY . .
+
+WORKDIR /home/spaceuser/Programming/robotics-prototype/robot/rospackages
+RUN source /opt/ros/$ROS_DISTRO/setup.sh \
+    && catkin_make -DPYTHON_EXECUTABLE=/usr/bin/python3 \
+    && chown -R spaceuser:spaceuser /home/spaceuser/Programming \
+    && chmod u+x /home/spaceuser/Programming/robotics-prototype/entrypoint.sh
+
+USER spaceuser
+WORKDIR /home/spaceuser/Programming/robotics-prototype
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/rosbridge/Dockerfile
+++ b/docker/rosbridge/Dockerfile
@@ -28,10 +28,16 @@ RUN apt-get update -y && apt-get upgrade -y \
     && apt-get install -y nano vim wget curl libfontconfig libx11-6 libxft2
 
 COPY install_arduino_teensyduino.sh .
-
 USER spaceuser
 RUN echo 'spaceuser' | sudo -S /home/spaceuser/Programming/robotics-prototype/install_arduino_teensyduino.sh 
 
+USER root
+COPY robot/rospackages ./robot/rospackages
+RUN rosdep init \
+    && rosdep update --rosdistro $ROS_DISTRO \
+    && rosdep install --from-paths robot/rospackages/src/ --ignore-src -r -y 
+
+USER spaceuser
 COPY robot/rover ./robot/rover
 WORKDIR /home/spaceuser/Programming/robotics-prototype/robot/rover
 RUN echo 'spaceuser' | sudo -S chown -R spaceuser:spaceuser /home/spaceuser \
@@ -43,10 +49,6 @@ RUN echo 'spaceuser' | sudo -S chown -R spaceuser:spaceuser /home/spaceuser \
 
 USER root
 WORKDIR /home/spaceuser/Programming/robotics-prototype
-COPY robot/rospackages ./robot/rospackages
-RUN rosdep init \
-    && rosdep update --rosdistro $ROS_DISTRO \
-    && rosdep install --from-paths robot/rospackages/src/ --ignore-src -r -y 
 
 COPY . .
 


### PR DESCRIPTION
# Assignee Section

## Description
  This PR improves the rosbridge image build process so that Docker can use its cache as much as possible when installing dependencies and run only the compilation steps when files have been edited on the host.
 
### Steps for Testing

 1. Run the project with docker using `docker-compose up --build` or follow the README instructions in the docker directory if it's your first time.
 2. `docker-compose down`
 3. Make some arbitrary code changes in the `rover` or `rospackages` directory that can be easily seen.
 4. `docker-compose up --build` again. The image building should take way less time. You should be able to tell from the build logs that Docker is only compiling source files.
5. Once everything is running again, you should be able to see whatever changes you've made reflected.

closes #475

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

  - [ ] Local Test Performed Successfully
  - [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

  For Pull Requests that do not include code changes, it is not required to perform the tests above.
