### PR TITLE
Set to N/A and stop front-end from yelling at you if temp is 999.9

### DIFF
--- a/robot/basestation/static/js/roslibjs/ros-helpers.js
+++ b/robot/basestation/static/js/roslibjs/ros-helpers.js
@@ -251,7 +251,8 @@ function initRosWeb () {
 
     $('.battery-temp').each(function(i, obj) {
       let $obj = $(obj)
-      let temperature = temps[i]
+      let temperature = temps[i] == 999.9 ? 'N/A ' : temps[i]
+
       $obj.text(temperature)
 
       if ((temperature > MAX_TEMP || temperature < MIN_TEMP)) {


### PR DESCRIPTION
# Assignee Section

## Description
Implement a check to replace the element with "N/A" if the temp is equal to 999.9

### Steps for Testing
1. `rosgui` and `startgui`
2. Open gui
3. `rostopic pub /battery_temps <TAB>x9999`
4. Set any temps to 999.9
5. Check in GUI that temp is now `N/A` and no popup came up
6. (Optional) Set temp to 999 and check that popup screams at you

closes #317 

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [ ] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
