### PR TITLE
[#489] Add autonomy-packages as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 [submodule "tf2_web_republisher"]
 	path = robot/rospackages/src/tf2_web_republisher
 	url = https://github.com/RobotWebTools/tf2_web_republisher
-[submodule "robot/rospackages/src/autonomy-packages"]
+[submodule "autonomy-packages"]
 	path = robot/rospackages/src/autonomy-packages
 	url = https://github.com/space-concordia-robotics/autonomy-packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "tf2_web_republisher"]
 	path = robot/rospackages/src/tf2_web_republisher
 	url = https://github.com/RobotWebTools/tf2_web_republisher
+[submodule "robot/rospackages/src/autonomy-packages"]
+	path = robot/rospackages/src/autonomy-packages
+	url = https://github.com/space-concordia-robotics/autonomy-packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,4 +78,4 @@ python:
   - "3.6"
 
 git:
-  submodules: true
+  submodules: false


### PR DESCRIPTION
# Assignee Section

## Description
Added autonomy-packages as submodule in catkin workspace in robotics-prototype

closes #489 

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [x] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
