### PR TITLE
Make the Serial available check before every Serial.read()

### DIFF
--- a/robot/rover/internal_comms/include/CommandCenter.h
+++ b/robot/rover/internal_comms/include/CommandCenter.h
@@ -37,5 +37,6 @@ namespace internal_comms
             uint16_t readArgSize() const;
     };
 
+    uint8_t waitForSerial();
 }
 #endif //INTERNAL_COMMS_COMMANDCENTER_H

--- a/robot/rover/internal_comms/src/CommandCenter.cpp
+++ b/robot/rover/internal_comms/src/CommandCenter.cpp
@@ -9,14 +9,14 @@ namespace internal_comms
 {
     Command* CommandCenter::processCommand() const
     {
-        uint8_t commandID = Serial.read();
-        uint8_t deviceSending = Serial.read();
-        uint8_t deviceReceiving = Serial.read();
+        uint8_t commandID = waitForSerial();
+        uint8_t deviceSending = waitForSerial();
+        uint8_t deviceReceiving = waitForSerial();
         uint16_t argumentSize = readArgSize();
 
         uint8_t* buffer = (uint8_t*) malloc(sizeof(uint8_t) * argumentSize);
         uint16_t bytesRead = (uint8_t) Serial.readBytes((char*)buffer, argumentSize);
-        uint8_t stopByte = Serial.read();
+        uint8_t stopByte = waitForSerial();
 
         Command* cmd = (Command*) malloc(sizeof(Command));
         cmd->commandID = commandID;
@@ -40,9 +40,20 @@ namespace internal_comms
     uint16_t CommandCenter::readArgSize() const 
     {
         // Serial.read() returns size_t
-        uint16_t byte1 = Serial.read();
-        uint8_t byte2 = Serial.read();
+        uint16_t byte1 = waitForSerial();
+        uint8_t byte2 = waitForSerial();
         uint16_t ArgumentsLength = (byte1 << 8) | byte2;
         return ArgumentsLength;
+    }
+
+    // Wait until there is something to read or 50ms have gone by
+    uint8_t waitForSerial()
+    {
+        unsigned long start = millis();
+        while(!Serial.available()){
+            unsigned long current = millis() - start;
+            if (current > 50) break;
+        }
+        return Serial.read();
     }
 }


### PR DESCRIPTION
# Assignee Section

## Description
Fixes the issue of getting garbage when back to back `Serial.read()`s are performed. If you `Serial.read()` before it's "ready" you run the risk of reading garbage values.

### Steps for Testing
Note: I tested using an Arduino Nano. I don't know what happens with a teensy. Also you need some code that links to and uses the internal comms library found in `robot/rover/internal_comms/`

1. In `robot/rover/internal_comms/src/CommandCenter.cpp` replace all instances of `waitForSerial()` with `Serial.read()`
2. Serial.print the two bytes inside `readArgSize()`
3. Compile and upload your program.
4. Run it, send in some bytes and you should see that you get corrupted values. In other words you don't get the same as the bytes you sent in.
5. Undo changes from 1
6. Run the experiment again. You should get the values you sent in this time

#### Additional info
It's not trivial to use the Arduino IDE for the testing steps above so I had to do everything from the commandline. Here's how:
##### Compiling
Use the provided Cmakelists.txt. These generate elf files
##### Uploading
The arduino ide will only upload a binary it compiled itself so we need to manually upload with avrdude. My command looked like the following `avrdude -C/home/bionic/arduino-1.8.12/hardware/tools/avr/etc/avrdude.conf -v -patmega328p -carduino -P/dev/ttyUSB0 -b57600 -D -Uflash:w:bin/PDS2.elf:e`. Just remember to change the device from `/dev/ttyUSB0` to whatever your device is and the path to avrdude.conf to the path on your system. Also put the path to your elf file in the last part : `-Uflash:w:<path/to/elf.elf>:e`

##### Sending bytes
The Arduino IDE's serial monitor only allows you to send ascii as far as I can tell. So I used python to send in raw bytes.
Basically in one terminal you should have `tail -f <device>` so for example `tail -f /dev/ttyUSB0`.
In another terminal you can run something like: `python3 -c "import sys; sys.stdout.buffer.write(b'\x36\x00\x02\x00\x02\x06\x64\x00')" > /dev/ttyUSB0` and you should see any results in the first terminal. If you don't see anything despite having some prints. Try sending data via the Serial monitor first and then retry this method.

closes nothing

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [ ] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
