### PR TITLE
Comms debug string

### DIFF
--- a/robot/rover/Arm/Arm.ino
+++ b/robot/rover/Arm/Arm.ino
@@ -25,7 +25,7 @@
   updated as of May 2021
 */
 
-#define UART
+#define UART_PORT
 
 #include <Servo.h>
 #include "include/PinSetup.h"
@@ -515,17 +515,11 @@ void m1_encoder_interrupt(void) {
      is cleared before accessing the array.
   */
   motor1.encoderCount += encoderStates[(oldEncoderState & 0x0F)] * motor1.encoderModifier;
-#ifdef DEBUG_ENCODERS
-  UART_PORT.print("ARM motor 1 "); UART_PORT.println(motor1.encoderCount);
-#endif
 #endif
 #ifdef M1_SINGLE_CHANNEL
   //! use this version if only one encoder channel is working
   // this doesn't seem to work though so maybe don't... or fix it
   motor1.encoderCount += motor1.rotationDirection * 2;
-#ifdef DEBUG_ENCODERS
-  UART_PORT.print("ARM motor 1 "); UART_PORT.println(motor1.encoderCount);
-#endif
 #endif
 }
 #endif
@@ -871,7 +865,6 @@ void emergencyStop()
 
 void pong() 
 {
-    char msg[4] = {'P','O','N','G'};
-    internal_comms::Message* message = commandCenter->createMessage(1, 4, msg);
+    internal_comms::Message* message = commandCenter->createMessage(1, 0, nullptr);
     commandCenter->sendMessage(*message);
 }

--- a/robot/rover/Arm/src/commands/ArmCommandCenter.cpp
+++ b/robot/rover/Arm/src/commands/ArmCommandCenter.cpp
@@ -21,7 +21,7 @@
 #define COMMAND_BUDGE_MOTORS 14
 #define COMMAND_MOVE_MULTIPLE_MOTORS 15
 #define COMMAND_PING 16
-#define COMMAND_PRINT_MOTOR_ANGLES 17
+#define COMMAND_GET_MOTOR_ANGLES 17
 
 void emergencyStop();
 void rebootTeensy();
@@ -100,7 +100,7 @@ void ArmCommandCenter::executeCommand(const uint8_t commandID, const uint8_t* ra
     case COMMAND_PING:
       pong();
       break;
-    case COMMAND_PRINT_MOTOR_ANGLES:
+    case COMMAND_GET_MOTOR_ANGLES:
       printMotorAngles();
       break;
   }

--- a/robot/rover/comms_demo/arduino_demos/pong_bing/pong_bing.ino
+++ b/robot/rover/comms_demo/arduino_demos/pong_bing/pong_bing.ino
@@ -20,22 +20,21 @@ void setup() {
 // the loop routine runs over and over again forever:
 void loop() {
 //  // read the input on analog pin 0:
-  int pingValue = 16;
-  char pong[] = {'P', 'O', 'N', 'G'};
+
+  int pingValue;
   Serial.write(pingValue);
-  Serial.write(sizeof(pong));
-  Serial.write(pong);
+  Serial.write(0);
   Serial.write(0x0A);
-  Serial.flush();
 
   delay(1000);
   
-  char bing[] = {'B', 'I', 'N', 'G'};
-  Serial.write(pingValue);
-  Serial.write(sizeof(bing));
-  Serial.write(bing);
+
+  int debugMessageID = 0;
+  char* message = "bing";
+  Serial.write(sizeof(message) + 1);
+  Serial.write(message);
   Serial.write(0x0A);
-  Serial.flush();
+
 
   delay(1000);
   
@@ -53,7 +52,6 @@ void loop() {
   byte* motorsByte = (byte*)motors;
   Serial.write(motorsByte, sizeof(motors));
   Serial.write(0x0A);
-  Serial.flush();
   delay(1000);
 
 }

--- a/robot/rover/comms_demo/arduino_demos/pong_bing/pong_bing.ino
+++ b/robot/rover/comms_demo/arduino_demos/pong_bing/pong_bing.ino
@@ -32,7 +32,7 @@ void loop() {
   int debugMessageID = 0;
   const char* message = "bing bang boom!!";
   Serial.write(debugMessageID);
-  Serial.write(strlen(message) + 1);
+  Serial.write(strlen(message));
   Serial.write(message);
   Serial.write(0x0A);
 

--- a/robot/rover/comms_demo/arduino_demos/pong_bing/pong_bing.ino
+++ b/robot/rover/comms_demo/arduino_demos/pong_bing/pong_bing.ino
@@ -21,7 +21,7 @@ void setup() {
 void loop() {
 //  // read the input on analog pin 0:
 
-  int pingValue;
+  int pingValue = 1;
   Serial.write(pingValue);
   Serial.write(0);
   Serial.write(0x0A);
@@ -30,15 +30,16 @@ void loop() {
   
 
   int debugMessageID = 0;
-  char* message = "bing";
-  Serial.write(sizeof(message) + 1);
+  const char* message = "bing bang boom!!";
+  Serial.write(debugMessageID);
+  Serial.write(strlen(message) + 1);
   Serial.write(message);
   Serial.write(0x0A);
 
 
   delay(1000);
   
-  int motorsValue = 17;
+  int motorsValue = 2;
   float motors[6];
   motors[0] = 0.0f;
   motors[1] = 1.25f;

--- a/robot/rover/internal_comms/include/CommandCenter.h
+++ b/robot/rover/internal_comms/include/CommandCenter.h
@@ -10,8 +10,10 @@
 
 #define COMMS_BAUDRATE 57600L
 
-#ifdef UART
-#define Serial Serial1
+#ifdef UART_PORT
+   #define Serial Serial1
+#elif USB_PORT
+   #define Serial Serial
 #endif
 
 namespace internal_comms
@@ -94,6 +96,12 @@ namespace internal_comms
              * Closes serial connection
              */
             void endSerial();
+
+
+            /**
+             * Send debug message string
+             */
+            void CommandCenter::sendDebug(char* debugMessage);
 
         private:
             uint8_t enablePin;

--- a/robot/rover/internal_comms/include/CommandCenter.h
+++ b/robot/rover/internal_comms/include/CommandCenter.h
@@ -101,7 +101,7 @@ namespace internal_comms
             /**
              * Send debug message string
              */
-            void CommandCenter::sendDebug(char* debugMessage);
+            void CommandCenter::sendDebug(const char* debugMessage);
 
         private:
             uint8_t enablePin;

--- a/robot/rover/internal_comms/src/CommandCenter.cpp
+++ b/robot/rover/internal_comms/src/CommandCenter.cpp
@@ -108,7 +108,7 @@ namespace internal_comms
         command = nullptr;
     }
 
-    void CommandCenter::sendDebug(char* debugMessage)
+    void CommandCenter::sendDebug(const char* debugMessage)
     {
         Message* message = this->createMessage(COMMAND_DEBUG_MSG, strlen(debugMessage) + 1, debugMessage);
         this->queueMessage(*message);

--- a/robot/rover/internal_comms/src/CommandCenter.cpp
+++ b/robot/rover/internal_comms/src/CommandCenter.cpp
@@ -110,7 +110,7 @@ namespace internal_comms
 
     void CommandCenter::sendDebug(const char* debugMessage)
     {
-        Message* message = this->createMessage(COMMAND_DEBUG_MSG, strlen(debugMessage) + 1, debugMessage);
+        Message* message = this->createMessage(COMMAND_DEBUG_MSG, strlen(debugMessage), debugMessage);
         this->queueMessage(*message);
     }
 


### PR DESCRIPTION
# Assignee Section

## Description
This PR just builds on the previous one to better integrate the new comms with the arm code. We basically added a python node and a  .ino file to test sending/reading commands

### Steps for Testing

1. Upload pong_bing.ino to an arduino
2. Uncomment the print statements in `ArmNode.py`
3. Run roscore + `python3  robot/rospackages/src/mcu_control/scripts/ArmNode.py`
4. You should see commands being printed out correctly. It includes an array of floats and a string.

The approval from all software team leads is necessary before merging.

# Reviewer Section

Aside from local testing and the General Integration Test it is implied that static analysis should be included in the verification process.

- [ ] Local Test Performed Successfully
- [ ] [General Integration Test](https://docs.google.com/document/d/1ug0CpA1cIzURP8DDFSvCt2CEJJSwJ6Ta6B1LG_hYk6I/edit) Performed Successfully

For Pull Requests that do not include code changes, it is not required to perform the tests above.
