### PR TITLE
[#0] Copy contents to avoid bad pointer

### DIFF
--- a/robot/rover/internal_comms/src/CommandCenter.cpp
+++ b/robot/rover/internal_comms/src/CommandCenter.cpp
@@ -127,9 +127,9 @@ namespace internal_comms
                     Serial.write(message.rawArgs, message.rawArgsLength);
 
                 Serial.write(0x0A);
-
-                free( (void *) &message);
-                //delete &message;
+                
+                free((void *)message.rawArgs);
+                free((void *)&message);
             }
             //else {
                 //Serial.write(1);

--- a/robot/rover/internal_comms/src/CommandCenter.cpp
+++ b/robot/rover/internal_comms/src/CommandCenter.cpp
@@ -58,7 +58,7 @@ namespace internal_comms
         Message* message = (Message*) malloc(sizeof(Message));
         message->messageID = messageID;
         message->rawArgsLength = rawArgsLength;
-        message->rawArgs = rawArgs;
+        memcpy(message->rawArgs, rawArgs, rawArgsLength);
         return message;
     }
 


### PR DESCRIPTION
# Assignee Section

## Description
The message object only has a reference to the contents but the contents may get cleared once the object was pushed to the message queue. To avoid problems, the contents are copied to a new address.
