### PR TITLE
[#547] Make pwm pin frequencies 18kHz

### DIFF
--- a/robot/rover/Arm/include/DcMotor.h
+++ b/robot/rover/Arm/include/DcMotor.h
@@ -39,6 +39,7 @@ DcMotor::DcMotor(int dirPin, int pwmPin, float gearRatio):// if no encoder
     setGearRatio(gearRatio);
     this -> motorType = DC_MOTOR;
     hasEncoder = false;
+    analogWriteFrequency(pwmPin, 18000);
 }
 
 void DcMotor::motorTimerInterrupt(void) {

--- a/robot/rover/MobilePlatform/src/DcMotor.cpp
+++ b/robot/rover/MobilePlatform/src/DcMotor.cpp
@@ -27,6 +27,7 @@ namespace Motor {
 
         pinMode(pwmPin, OUTPUT);
         pinMode(dirPin, OUTPUT);
+        analogWriteFrequency(pwmPin, 18000);
     }
 
     void initPidController(const MotorNames &motorID, const float& kp, const float& ki, const float& kd) {


### PR DESCRIPTION
Upgraded the motor pwm pin frequencies to 18kHz to greatly reduce the 2V dip in the power rail. 
Josh must confirm that it worked.